### PR TITLE
Module Twin Test Hotfix

### DIFF
--- a/ci-wrappers/c/wrapper/glue/InternalGlue.cpp
+++ b/ci-wrappers/c/wrapper/glue/InternalGlue.cpp
@@ -19,6 +19,7 @@
 #include "iothubtransportmqtt_websockets.h"
 #include "iothub.h"
 #include "parson.h"
+#include "iothub_client_options.h"
 
 #include "GlueUtils.h"
 #include "InternalGlue.h"
@@ -125,8 +126,11 @@ string InternalGlue::Connect(const char *transportType, std::string connectionSt
         cout << "InternalGlue::Connect Client Pointer: " << address << endl;
         bool traceOn = true;
         bool rawTraceOn = true;
-        IoTHubModuleClient_SetOption(client, "logtrace", &traceOn);
-        IoTHubModuleClient_SetOption(client, "rawlogtrace", &rawTraceOn);
+        
+        IoTHubModuleClient_SetOption(client, OPTION_LOG_TRACE, &traceOn);
+        IoTHubModuleClient_SetOption(client, "rawlogtrace", &rawTraceOn)
+        size_t sasTime = 10;
+        IoTHubModuleClient_SetOption(client, OPTION_SAS_TOKEN_LIFETIME, &sasTime);
 
         string clientId = getNextClientId();
         this->clientMap[clientId] = (void *)client;
@@ -152,8 +156,10 @@ string InternalGlue::ConnectFromEnvironment(const char *transportType)
     {
         bool traceOn = true;
         bool rawTraceOn = true;
-        IoTHubModuleClient_SetOption(client, "logtrace", &traceOn);
+        IoTHubModuleClient_SetOption(client, OPTION_LOG_TRACE, &traceOn);
         IoTHubModuleClient_SetOption(client, "rawlogtrace", &rawTraceOn);
+        size_t sasTime = 10;
+        IoTHubModuleClient_SetOption(client, OPTION_SAS_TOKEN_LIFETIME, &sasTime);
 
         string clientId = getNextClientId();
         this->clientMap[clientId] = (void *)client;

--- a/ci-wrappers/c/wrapper/glue/InternalGlue.cpp
+++ b/ci-wrappers/c/wrapper/glue/InternalGlue.cpp
@@ -128,7 +128,7 @@ string InternalGlue::Connect(const char *transportType, std::string connectionSt
         bool rawTraceOn = true;
         
         IoTHubModuleClient_SetOption(client, OPTION_LOG_TRACE, &traceOn);
-        IoTHubModuleClient_SetOption(client, "rawlogtrace", &rawTraceOn)
+        IoTHubModuleClient_SetOption(client, "rawlogtrace", &rawTraceOn);
         size_t sasTime = 10;
         IoTHubModuleClient_SetOption(client, OPTION_SAS_TOKEN_LIFETIME, &sasTime);
 

--- a/test-runner/test_module_twin_desired_properties.py
+++ b/test-runner/test_module_twin_desired_properties.py
@@ -81,6 +81,11 @@ def test_service_can_set_multiple_desired_property_patches_and_module_can_retrie
     module_client = connections.connect_test_module_client()
     log_message("enabling twin")
     module_client.enable_twin()
+    log_message("getting initial twin patch")
+    twin_thread = module_client.wait_for_desired_property_patch_async()    
+    log_message("waiting for twin to arrive at module client")
+    twin_received = patch_thread.get()
+    log_message("twin received:" + json.dumps(patch_received))
 
     base = random.randint(1, 9999) * 100
     for i in range(1, 4):

--- a/test-runner/test_module_twin_desired_properties.py
+++ b/test-runner/test_module_twin_desired_properties.py
@@ -94,6 +94,10 @@ def test_service_can_set_multiple_desired_property_patches_and_module_can_retrie
 
         log_message("start waiting for patch #" + str(i))
         patch_thread = module_client.wait_for_desired_property_patch_async()
+        log_message("resend patch just in case")
+        registry_client.patch_module_twin(
+            environment.edge_device_id, environment.module_id, twin_sent
+        )
         log_message("waiting for patch " + str(i) + " to arrive at module client")
         patch_received = patch_thread.get()
         log_message("patch received:" + json.dumps(patch_received))

--- a/test-runner/test_module_twin_desired_properties.py
+++ b/test-runner/test_module_twin_desired_properties.py
@@ -81,16 +81,9 @@ def test_service_can_set_multiple_desired_property_patches_and_module_can_retrie
     module_client = connections.connect_test_module_client()
     log_message("enabling twin")
     module_client.enable_twin()
-    log_message("getting initial twin patch")
-    twin_thread = module_client.wait_for_desired_property_patch_async()    
-    log_message("waiting for twin to arrive at module client")
-    twin_received = patch_thread.get()
-    log_message("twin received:" + json.dumps(patch_received))
 
     base = random.randint(1, 9999) * 100
     for i in range(1, 4):
-        log_message("start waiting for patch #" + str(i))
-        patch_thread = module_client.wait_for_desired_property_patch_async()
 
         log_message("sending patch #" + str(i) + " through registry client")
         twin_sent = {"properties": {"desired": {"foo": base + i}}}
@@ -99,6 +92,8 @@ def test_service_can_set_multiple_desired_property_patches_and_module_can_retrie
         )
         log_message("patch " + str(i) + " sent")
 
+        log_message("start waiting for patch #" + str(i))
+        patch_thread = module_client.wait_for_desired_property_patch_async()
         log_message("waiting for patch " + str(i) + " to arrive at module client")
         patch_received = patch_thread.get()
         log_message("patch received:" + json.dumps(patch_received))


### PR DESCRIPTION
The current test_module_twin_desired_properties:test_service_can_set_multiple_desired_property_patches_and_module_can_retrieve_them_as_events enables the Device Twin Callback, then patches the Module Twin via the Registry Client. This is fine assuming that the Device Twin Callback is never called in between the setting of the Callback and patching the Module Twin. This assumption though should be moved to a separate test in itself. For now, this hotfix switches the order of the calls, so the Registry Client is first used to patch the Module Twin, then the Device Twin callback is set. To ensure the callback is called, the Patch is sent a second time with the same value. 

Thus, two cases will still result in success for the test:

* in the case where the twin callback is called multiple times
*  the case that the twin callback is only called once, following a patch set by the registry client 