### PR TITLE
device tests sync async

### DIFF
--- a/test-runner/adapters/abstract_device_api.py
+++ b/test-runner/adapters/abstract_device_api.py
@@ -1,0 +1,30 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+import six
+import abc
+
+
+@six.add_metaclass(abc.ABCMeta)
+class AbstractDeviceApi:
+
+    @abc.abstractmethod
+    async def connect(self, transport, connection_string, ca_certificate):
+        pass
+
+    @abc.abstractmethod
+    async def disconnect(self):
+        pass
+
+    @abc.abstractmethod
+    async def send_event(self, body):
+        pass
+
+    @abc.abstractmethod
+    async def enable_methods(self):
+        pass
+
+    @abc.abstractmethod
+    async def roundtrip_method_async(self, method_name, status_code, request_payload, response_payload):
+        pass

--- a/test-runner/adapters/abstract_device_api.py
+++ b/test-runner/adapters/abstract_device_api.py
@@ -22,6 +22,10 @@ class AbstractDeviceApi:
         pass
 
     @abc.abstractmethod
+    async def receive_c2d(self):
+        pass
+
+    @abc.abstractmethod
     async def enable_methods(self):
         pass
 

--- a/test-runner/adapters/abstract_module_api.py
+++ b/test-runner/adapters/abstract_module_api.py
@@ -10,67 +10,63 @@ import abc
 @six.add_metaclass(abc.ABCMeta)
 class AbstractModuleApi:
     @abc.abstractmethod
-    def connect(self, transport, connection_string, ca_certificate):
+    async def connect(self, transport, connection_string, ca_certificate):
         pass
 
     @abc.abstractmethod
-    def connect_from_environment(self, transport):
+    async def connect_from_environment(self, transport):
         pass
 
     @abc.abstractmethod
-    def disconnect(self):
+    async def disconnect(self):
         pass
 
     @abc.abstractmethod
-    def enable_twin(self):
+    async def enable_twin(self):
         pass
 
     @abc.abstractmethod
-    def enable_methods(self):
+    async def enable_methods(self):
         pass
 
     @abc.abstractmethod
-    def enable_input_messages(self):
+    async def enable_input_messages(self):
         pass
 
     @abc.abstractmethod
-    def get_twin(self):
+    async def get_twin(self):
         pass
 
     @abc.abstractmethod
-    def patch_twin(self, patch):
+    async def patch_twin(self, patch):
         pass
 
     @abc.abstractmethod
-    def wait_for_desired_property_patch_async(self):
+    async def wait_for_desired_property_patch_async(self):
         pass
 
     @abc.abstractmethod
-    def send_event(self, body):
+    async def send_event(self, body):
         pass
 
     @abc.abstractmethod
-    def send_event_async(self, body):
+    async def send_output_event(self, output_name, body):
         pass
 
     @abc.abstractmethod
-    def send_output_event(self, output_name, body):
+    async def wait_for_input_event_async(self, input_name):
         pass
 
     @abc.abstractmethod
-    def wait_for_input_event_async(self, input_name):
+    async def call_module_method_async(self, device_id, module_id, method_invoke_parameters):
         pass
 
     @abc.abstractmethod
-    def call_module_method_async(self, device_id, module_id, method_invoke_parameters):
+    async def call_device_method_async(self, device_id, method_invoke_parameters):
         pass
 
     @abc.abstractmethod
-    def call_device_method_async(self, device_id, method_invoke_parameters):
-        pass
-
-    @abc.abstractmethod
-    def roundtrip_method_async(
+    async def roundtrip_method_async(
         self, method_name, status_code, request_payload, response_payload
     ):
         pass

--- a/test-runner/adapters/direct_python_sdk/__init__.py
+++ b/test-runner/adapters/direct_python_sdk/__init__.py
@@ -4,12 +4,19 @@
 # Licensed under the MIT license. See LICENSE file in the project root for
 # full license information.
 
-from .direct_module_api import ModuleApi, object_list
+from .direct_module_api import ModuleApi, object_list_sync
+from .direct_module_api_aio import ModuleApiAsync, object_list_async
+from .direct_device_api import DeviceApi, object_list_sync
+from .direct_device_api_aio import DeviceApiAsync, object_list_async
 
 
 def cleanup_test_objects():
     # We need to operate on a copy of the list because the disconnect
     # function modifies object_list which breaks the iteration
-    list_copy = object_list.copy()
-    for obj in list_copy:
+    list_copy_async = object_list_sync.copy()
+    for obj in list_copy_async:
+        obj.disconnect()
+
+    list_copy_async = object_list_async.copy()
+    for obj in list_copy_async:
         obj.disconnect()

--- a/test-runner/adapters/direct_python_sdk/direct_device_api.py
+++ b/test-runner/adapters/direct_python_sdk/direct_device_api.py
@@ -40,6 +40,10 @@ class DeviceApi(AbstractDeviceApi):
         self.sync_client.send_event(body)
         print("send confirmation received")
 
+    def receive_c2d(self):
+        c2d_message_queue = self.sync_client.get_c2d_message_queue()
+        return c2d_message_queue
+
     def enable_methods(self):
         raise NotImplementedError
 

--- a/test-runner/adapters/direct_python_sdk/direct_device_api.py
+++ b/test-runner/adapters/direct_python_sdk/direct_device_api.py
@@ -1,0 +1,47 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from ..abstract_device_api import AbstractDeviceApi
+from azure.iot.hub.devicesdk.sync_clients import DeviceClient as DeviceClientSync
+from azure.iot.hub.devicesdk.auth.authentication_provider_factory import from_connection_string
+
+object_list_sync = []
+
+
+class DeviceApi(AbstractDeviceApi):
+    def __init__(self):
+        self.auth_provider = None
+        self.sync_client = None
+        self.async_client = None
+
+    def connect(self, transport, connection_string, ca_certificate):
+        print("connecting using " + transport)
+        self.auth_provider = from_connection_string(connection_string)
+        if ca_certificate and "cert" in ca_certificate:
+            self.auth_provider.ca_cert = ca_certificate["cert"]
+        self.sync_client = DeviceClientSync.from_authentication_provider(self.auth_provider, transport)
+        object_list_sync.append(self)
+        self.sync_client.connect()
+
+    def disconnect(self):
+        if self in object_list_sync:
+            object_list_sync.remove(self)
+
+        self.sync_client.disconnect()
+        self.sync_client = None
+
+        self.auth_provider.disconnect()
+        self.auth_provider = None
+
+    def send_event(self, body):
+        print("sending event")
+        self.sync_client.send_event(body)
+        print("send confirmation received")
+
+    def enable_methods(self):
+        raise NotImplementedError
+
+    def roundtrip_method_async(self, method_name, status_code, request_payload, response_payload):
+        raise NotImplementedError

--- a/test-runner/adapters/direct_python_sdk/direct_device_api_aio.py
+++ b/test-runner/adapters/direct_python_sdk/direct_device_api_aio.py
@@ -1,0 +1,47 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from ..abstract_device_api import AbstractDeviceApi
+from azure.iot.hub.devicesdk.aio.async_clients import DeviceClient as DeviceClientAsync
+from azure.iot.hub.devicesdk.auth.authentication_provider_factory import from_connection_string
+
+
+object_list_async = []
+
+
+class DeviceApiAsync(AbstractDeviceApi):
+    def __init__(self):
+        self.auth_provider = None
+        self.async_client = None
+
+    async def connect(self, transport, connection_string, ca_certificate):
+        print("connecting async using " + transport)
+        self.auth_provider = from_connection_string(connection_string)
+        if ca_certificate and "cert" in ca_certificate:
+            self.auth_provider.ca_cert = ca_certificate["cert"]
+        self.async_client = await DeviceClientAsync.from_authentication_provider(self.auth_provider, transport)
+        object_list_async.append(self)
+        await self.async_client.connect()
+
+    async def disconnect(self):
+        if self in object_list_async:
+            object_list_async.remove(self)
+
+        await self.async_client.disconnect()
+        self.async_client = None
+
+        self.auth_provider.disconnect()
+        self.auth_provider = None
+
+    async def send_event(self, body):
+        print("sending event using async")
+        await self.async_client.send_event(body)
+        print("send confirmation received")
+
+    async def enable_methods(self):
+        pass
+
+    async def roundtrip_method_async(self, method_name, status_code, request_payload, response_payload):
+        raise NotImplementedError

--- a/test-runner/adapters/direct_python_sdk/direct_device_api_aio.py
+++ b/test-runner/adapters/direct_python_sdk/direct_device_api_aio.py
@@ -40,6 +40,9 @@ class DeviceApiAsync(AbstractDeviceApi):
         await self.async_client.send_event(body)
         print("send confirmation received")
 
+    async def receive_c2d(self):
+        pass
+
     async def enable_methods(self):
         pass
 

--- a/test-runner/adapters/direct_python_sdk/direct_module_api.py
+++ b/test-runner/adapters/direct_python_sdk/direct_module_api.py
@@ -62,7 +62,8 @@ class ModuleApi(AbstractModuleApi):
         raise NotImplementedError()
 
     def enable_input_messages(self):
-        raise NotImplementedError()
+        # TODO : Should take input name as param ?
+        input_message_queue = self.sync_client.get_input_message_queue("input1")
 
     def get_twin(self):
         raise NotImplementedError()

--- a/test-runner/adapters/direct_python_sdk/direct_module_api.py
+++ b/test-runner/adapters/direct_python_sdk/direct_module_api.py
@@ -8,7 +8,7 @@ import base64
 import json
 from ..print_message import print_message
 from ..abstract_module_api import AbstractModuleApi
-from azure.iot.hub.devicesdk import ModuleClient
+from azure.iot.hub.devicesdk.sync_clients import ModuleClient as ModuleClientSync
 from azure.iot.hub.devicesdk.auth.authentication_provider_factory import (
     from_connection_string,
     from_environment,
@@ -16,40 +16,41 @@ from azure.iot.hub.devicesdk.auth.authentication_provider_factory import (
 
 # logging.basicConfig(level=logging.INFO)
 
-object_list = []
+object_list_sync = []
 
 
 class ModuleApi(AbstractModuleApi):
     def __init__(self):
         self.auth_provider = None
-        self.client = None
+        self.sync_client = None
+        self.async_client = None
 
     def connect(self, transport, connection_string, ca_certificate):
         print("connecting using " + transport)
         self.auth_provider = from_connection_string(connection_string)
         if ca_certificate and "cert" in ca_certificate:
             self.auth_provider.ca_cert = ca_certificate["cert"]
-        self.client = ModuleClient.from_authentication_provider(
+        self.sync_client = ModuleClientSync.from_authentication_provider(
             self.auth_provider, transport
         )
-        object_list.append(self)
-        self.client.connect()
+        object_list_sync.append(self)
+        self.sync_client.connect()
 
     def connect_from_environment(self, transport):
         print("connecting from environment")
         self.auth_provider = from_environment()
-        self.client = ModuleClient.from_authentication_provider(
+        self.sync_client = ModuleClientSync.from_authentication_provider(
             self.auth_provider, transport
         )
-        object_list.append(self)
-        self.client.connect()
+        object_list_sync.append(self)
+        self.sync_client.connect()
 
     def disconnect(self):
-        if self in object_list:
-            object_list.remove(self)
+        if self in object_list_sync:
+            object_list_sync.remove(self)
 
-        self.client.disconnect()
-        self.client = None
+        self.sync_client.disconnect()
+        self.sync_client = None
 
         self.auth_provider.disconnect()
         self.auth_provider = None
@@ -74,17 +75,14 @@ class ModuleApi(AbstractModuleApi):
 
     def send_event(self, body):
         print("sending event")
-        self.client.send_event(body)
+        self.sync_client.send_event(body)
         print("send confirmation received")
-
-    def send_event_async(self, body):
-        raise NotImplementedError()
 
     def send_output_event(self, output_name, body):
         print("sending output event")
         if isinstance(body, str):
             body = json.dumps(body)
-        self.client.send_to_output(body, output_name)
+        self.sync_client.send_to_output(body, output_name)
         print("send confirmation received")
 
     def wait_for_input_event_async(self, input_name):

--- a/test-runner/adapters/direct_python_sdk/direct_module_api_aio.py
+++ b/test-runner/adapters/direct_python_sdk/direct_module_api_aio.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for
+# full license information.
+import logging
+import base64
+from ..print_message import print_message
+import json
+from ..abstract_module_api import AbstractModuleApi
+from azure.iot.hub.devicesdk.aio.async_clients import ModuleClient as ModuleClientAsync
+from azure.iot.hub.devicesdk.auth.authentication_provider_factory import (
+    from_connection_string,
+    from_environment,
+)
+
+# logging.basicConfig(level=logging.INFO)
+
+object_list_async = []
+
+
+class ModuleApiAsync(AbstractModuleApi):
+    def __init__(self):
+        self.auth_provider = None
+        self.async_client = None
+
+    async def connect(self, transport, connection_string, ca_certificate):
+        print("connecting using " + transport)
+        self.auth_provider = from_connection_string(connection_string)
+        if ca_certificate and "cert" in ca_certificate:
+            self.auth_provider.ca_cert = ca_certificate["cert"]
+        self.async_client = await ModuleClientAsync.from_authentication_provider(
+            self.auth_provider, transport
+        )
+        object_list_async.append(self)
+        await self.async_client.connect()
+
+    async def connect_from_environment(self, transport):
+        print("connecting from environment")
+        self.auth_provider = from_environment()
+        self.async_client = await ModuleClientAsync.from_authentication_provider(
+            self.auth_provider, transport
+        )
+        object_list_async.append(self)
+        await self.async_client.connect()
+
+    async def disconnect(self):
+        if self in object_list_async:
+            object_list_async.remove(self)
+
+        await self.async_client.disconnect()
+        self.async_client = None
+
+        self.auth_provider.disconnect()
+        self.auth_provider = None
+
+    async def send_event(self, body):
+        print("sending event")
+        await self.async_client.send_event(body)
+        print("send confirmation received")
+
+    async def enable_twin(self):
+        raise NotImplementedError()
+
+    async def enable_methods(self):
+        raise NotImplementedError()
+
+    async def enable_input_messages(self):
+        raise NotImplementedError()
+
+    async def get_twin(self):
+        raise NotImplementedError()
+
+    async def patch_twin(self, patch):
+        raise NotImplementedError()
+
+    async def wait_for_desired_property_patch_async(self):
+        raise NotImplementedError()
+
+    async def send_output_event(self, output_name, body):
+        print("sending output event")
+        if isinstance(body, str):
+            body = json.dumps(body)
+        await self.async_client.send_to_output(body, output_name)
+        print("send confirmation received")
+
+    async def wait_for_input_event_async(self, input_name):
+        raise NotImplementedError()
+
+    async def call_module_method_async(self, device_id, module_id, method_invoke_parameters):
+        raise NotImplementedError()
+
+    async def call_device_method_async(self, device_id, method_invoke_parameters):
+        raise NotImplementedError()
+
+    async def roundtrip_method_async(
+            self, method_name, status_code, request_payload, response_payload
+    ):
+        raise NotImplementedError()

--- a/test-runner/conftest.py
+++ b/test-runner/conftest.py
@@ -126,7 +126,6 @@ skip_for_pythonpreview = set(
         "invokesDeviceMethodCalls",
         "supportsTwin",
         "handlesLoopbackMessages",
-        "module_under_test_has_device_wrapper",
     ]
 )
 

--- a/test-runner/connections.py
+++ b/test-runner/connections.py
@@ -23,6 +23,22 @@ def connect_test_module_client():
     return client
 
 
+async def connect_test_module_client_async():
+    """
+    connect the module client for the code-under-test and return the client object
+    """
+    client = adapters.TestModuleClientAsync()
+    if environment.test_module_connect_from_environment:
+        await client.connect_from_environment(environment.test_module_transport)
+    else:
+        await client.connect(
+            environment.test_module_transport,
+            environment.test_module_connection_string,
+            environment.ca_certificate,
+        )
+    return client
+
+
 def connect_friend_module_client():
     """
     connect the module client for the friend module and return the client object
@@ -72,6 +88,19 @@ def connect_leaf_device_client():
     """
     client = adapters.LeafDeviceClient()
     client.connect(
+        environment.leaf_device_transport,
+        environment.leaf_device_connection_string,
+        environment.ca_certificate,
+    )
+    return client
+
+
+async def connect_leaf_device_client_async():
+    """
+    connect the device client for the leaf device and return the client object
+    """
+    client = adapters.LeafDeviceClientAsync()
+    await client.connect(
         environment.leaf_device_transport,
         environment.leaf_device_connection_string,
         environment.ca_certificate,

--- a/test-runner/environment.py
+++ b/test-runner/environment.py
@@ -248,6 +248,15 @@ def setupExecutionEnvironment():
         adapters.add_direct_python_sdk_adapter(
             name="TestModuleClient", api_surface="ModuleApi"
         )
+        adapters.add_direct_python_sdk_adapter(
+            name="TestModuleClientAsync", api_surface="ModuleApiAsync"
+        )
+        adapters.add_direct_python_sdk_adapter(
+            name="LeafDeviceClient", api_surface="DeviceApi"
+        )
+        adapters.add_direct_python_sdk_adapter(
+            name="LeafDeviceClientAsync", api_surface="DeviceApiAsync"
+        )
         adapters.add_direct_azure_rest_adapter(
             name="RegistryClient", api_surface="RegistryApi"
         )
@@ -264,12 +273,12 @@ def setupExecutionEnvironment():
         adapters.add_rest_adapter(
             name="ServiceClient", api_surface="ServiceApi", uri=service_client_uri
         )
+        adapters.add_rest_adapter(
+            name="LeafDeviceClient", api_surface="DeviceApi", uri=leaf_device_uri
+        )
 
     adapters.add_rest_adapter(
         name="FriendModuleClient", api_surface="ModuleApi", uri=friend_module_uri
-    )
-    adapters.add_rest_adapter(
-        name="LeafDeviceClient", api_surface="DeviceApi", uri=leaf_device_uri
     )
     adapters.add_direct_azure_rest_adapter(
         name="EventHubClient", api_surface="EventHubApi"

--- a/test-runner/test_connect_disconnect.py
+++ b/test-runner/test_connect_disconnect.py
@@ -15,6 +15,13 @@ def test_module_client_connect_disconnect():
     module_client.disconnect()
 
 
+@pytest.mark.asyncio
+@pytest.mark.testgroup_iothub_module_client
+async def test_module_client_connect_disconnect_async():
+    module_client_async = await connections.connect_test_module_client_async()
+    await module_client_async.disconnect()
+
+
 @pytest.mark.testgroup_edgehub_module_client
 @pytest.mark.testgroup_iothub_module_client
 @pytest.mark.supportsTwin
@@ -70,3 +77,17 @@ def test_device_client_connect_enable_methods_disconnect():
     device_client = connections.connect_leaf_device_client()
     device_client.enable_methods()
     device_client.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.testgroup_iothub_module_client
+async def test_device_client_connect_disconnect_async():
+    device_client_async = await connections.connect_leaf_device_client_async()
+    await device_client_async.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.testgroup_iothub_module_client
+async def test_module_client_connect_disconnect_async():
+    module_client_async = await connections.connect_test_module_client_async()
+    await module_client_async.disconnect()

--- a/test-runner/test_device_receive_c2d.py
+++ b/test-runner/test_device_receive_c2d.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for
+# full license information.
+
+import pytest
+import connections
+import test_utilities
+import environment
+from adapters import print_message as log_message
+import concurrent
+import asyncio
+import time
+
+
+@pytest.mark.testgroup_iothub_module_client
+@pytest.mark.callsSendEvent
+def test_device_receive_c2d_from_iothub():
+
+    # sent_message = test_utilities.random_string_in_json()
+    # log_message("sending event: " + str(sent_message))
+
+    log_message("connecting device client")
+    device_client = connections.connect_leaf_device_client()
+
+    expected_message = "Mimbulus Mimbletonia"
+    service = connections.connect_service_client()
+    service.send_c2d(environment.leaf_device_id, expected_message)
+    service.disconnect()
+
+    log_message("wait for event to arrive at device client ")
+    c2d_message_queue = device_client.receive_c2d()
+    received_c2d_message = wait_for_c2d_message(c2d_message_queue, 40, environment.leaf_device_id, expected_message)
+
+    if not received_c2d_message:
+        log_message("Message not received")
+        assert False
+
+    log_message("disconnecting device client")
+    device_client.disconnect()
+
+
+def wait_for_c2d_message(c2d_message_queue, timeout, device_id, expected=None):
+    log_message("DeviceAPI: waiting for c2d at {}".format(device_id))
+    start_time = time.time()
+    received_c2d_message = c2d_message_queue.get()  # blocking cal
+    return received_c2d_message
+    # while (time.time() - start_time) < timeout:
+    #     received_c2d_message = c2d_message_queue.get()  # blocking call
+    #     log_message("The message received was " + received_c2d_message)
+    #     if expected == received_c2d_message:
+    #         log_message("DeviceAPI: message received as expected")
+    #         return received_c2d_message
+    #     else:
+    #         log_message("DeviceAPI: unexpected message.  skipping")
+    # return received_c2d_message

--- a/test-runner/test_device_receive_c2d.py
+++ b/test-runner/test_device_receive_c2d.py
@@ -34,9 +34,7 @@ def test_device_receive_c2d_from_iothub_single():
     listen_thread.daemon = True
     listen_thread.start()
 
-    print("This may print while the thread is running.")
     listen_thread.join(10)
-    print("This will always print after the thread has finished.")
 
     result_message = result_messages[0]
     if not result_message:

--- a/test-runner/test_device_receive_c2d.py
+++ b/test-runner/test_device_receive_c2d.py
@@ -9,9 +9,8 @@ import connections
 import test_utilities
 import environment
 from adapters import print_message as log_message
-import concurrent
-import asyncio
 import time
+import threading
 
 
 @pytest.mark.testgroup_iothub_module_client
@@ -23,17 +22,19 @@ def test_device_receive_c2d_from_iothub():
 
     log_message("connecting device client")
     device_client = connections.connect_leaf_device_client()
-
     expected_message = "Mimbulus Mimbletonia"
+
+    log_message("wait for event to arrive at device client ")
+    c2d_message_queue = device_client.receive_c2d()
+
     service = connections.connect_service_client()
     service.send_c2d(environment.leaf_device_id, expected_message)
     service.disconnect()
 
-    log_message("wait for event to arrive at device client ")
-    c2d_message_queue = device_client.receive_c2d()
-    received_c2d_message = wait_for_c2d_message(c2d_message_queue, 40, environment.leaf_device_id, expected_message)
+    time.sleep(2)
 
-    if not received_c2d_message:
+    result_message = c2d_message_queue.get()
+    if not result_message:
         log_message("Message not received")
         assert False
 
@@ -41,17 +42,16 @@ def test_device_receive_c2d_from_iothub():
     device_client.disconnect()
 
 
-def wait_for_c2d_message(c2d_message_queue, timeout, device_id, expected=None):
+def wait_for_c2d_message(c2d_message_queue, timeout, device_id, result_message=None, expected=None):
     log_message("DeviceAPI: waiting for c2d at {}".format(device_id))
     start_time = time.time()
-    received_c2d_message = c2d_message_queue.get()  # blocking cal
-    return received_c2d_message
-    # while (time.time() - start_time) < timeout:
-    #     received_c2d_message = c2d_message_queue.get()  # blocking call
-    #     log_message("The message received was " + received_c2d_message)
-    #     if expected == received_c2d_message:
-    #         log_message("DeviceAPI: message received as expected")
-    #         return received_c2d_message
-    #     else:
-    #         log_message("DeviceAPI: unexpected message.  skipping")
-    # return received_c2d_message
+    while (time.time() - start_time) < timeout:
+        received_c2d_message = c2d_message_queue.get()
+        actual = str(received_c2d_message.data, "utf-8")
+        log_message("The message received was " + actual)
+        if expected == actual:
+            log_message("DeviceAPI: message received as expected")
+            result_message = actual
+        else:
+            log_message("DeviceAPI: unexpected message.  skipping")
+    return result_message

--- a/test-runner/test_device_receive_c2d.py
+++ b/test-runner/test_device_receive_c2d.py
@@ -6,7 +6,6 @@
 
 import pytest
 import connections
-import test_utilities
 import environment
 from adapters import print_message as log_message
 import time
@@ -15,25 +14,31 @@ import threading
 
 @pytest.mark.testgroup_iothub_module_client
 @pytest.mark.callsSendEvent
-def test_device_receive_c2d_from_iothub():
-
-    # sent_message = test_utilities.random_string_in_json()
-    # log_message("sending event: " + str(sent_message))
+def test_device_receive_c2d_from_iothub_single():
 
     log_message("connecting device client")
     device_client = connections.connect_leaf_device_client()
-    expected_message = "Mimbulus Mimbletonia"
+    expected_message = "This is an end to end message"
 
     log_message("wait for event to arrive at device client ")
     c2d_message_queue = device_client.receive_c2d()
 
+    expected_messages = [None] * 1
+    expected_messages[0] = expected_message
     service = connections.connect_service_client()
     service.send_c2d(environment.leaf_device_id, expected_message)
     service.disconnect()
 
-    time.sleep(2)
+    result_messages = [None] * 1
+    listen_thread = threading.Thread(target=wait_for_c2d_message, args=(c2d_message_queue, 5, environment.leaf_device_id, result_messages, expected_messages, 0, 1))
+    listen_thread.daemon = True
+    listen_thread.start()
 
-    result_message = c2d_message_queue.get()
+    print("This may print while the thread is running.")
+    listen_thread.join(10)
+    print("This will always print after the thread has finished.")
+
+    result_message = result_messages[0]
     if not result_message:
         log_message("Message not received")
         assert False
@@ -42,16 +47,60 @@ def test_device_receive_c2d_from_iothub():
     device_client.disconnect()
 
 
-def wait_for_c2d_message(c2d_message_queue, timeout, device_id, result_message=None, expected=None):
+@pytest.mark.testgroup_iothub_module_client
+@pytest.mark.callsSendEvent
+def test_device_receive_c2d_from_iothub_multiple():
+
+    number_of_messages = 3
+    log_message("connecting device client")
+    device_client = connections.connect_leaf_device_client()
+    expected_message = "This is an end to end message numbered"
+    expected_messages = [None] * number_of_messages
+
+    log_message("wait for event to arrive at device client ")
+    c2d_message_queue = device_client.receive_c2d()
+
+    for i in range(0, number_of_messages):
+        # We have to connect service client in a new instance always as we get following error
+        # ValueError: The supplied authentication has already been consumed by another connection.
+        # Please create a fresh instance.
+        service = connections.connect_service_client()
+        expected_messages[i] = expected_message + " i"
+        time.sleep(2)
+        service.send_c2d(environment.leaf_device_id, expected_messages[i])
+        service.disconnect()
+
+    result_messages = [None] * number_of_messages
+    listen_thread = threading.Thread(target=wait_for_c2d_message, args=(c2d_message_queue, 10, environment.leaf_device_id, result_messages, expected_messages, 0, number_of_messages))
+    listen_thread.daemon = True
+    listen_thread.start()
+
+    print("This may print while the thread is running.")
+    listen_thread.join(20)
+    print("This will always print after the thread has finished.")
+
+    for i in range(0, number_of_messages):
+        result_message = result_messages[i]
+        if not result_message:
+            log_message("Message not received")
+            assert False
+
+    log_message("disconnecting device client")
+    device_client.disconnect()
+
+
+def wait_for_c2d_message(c2d_message_queue, timeout, device_id, results, expected, index, capacity):
     log_message("DeviceAPI: waiting for c2d at {}".format(device_id))
     start_time = time.time()
     while (time.time() - start_time) < timeout:
         received_c2d_message = c2d_message_queue.get()
         actual = str(received_c2d_message.data, "utf-8")
         log_message("The message received was " + actual)
-        if expected == actual:
+        if expected[index] == actual:
             log_message("DeviceAPI: message received as expected")
-            result_message = actual
+            results[index] = actual
+            if index == capacity:
+                return
+            index = index + 1
         else:
             log_message("DeviceAPI: unexpected message.  skipping")
-    return result_message

--- a/test-runner/test_device_send_telemetry.py
+++ b/test-runner/test_device_send_telemetry.py
@@ -6,7 +6,6 @@
 
 import pytest
 import connections
-import random
 import test_utilities
 import environment
 from adapters import print_message as log_message
@@ -14,23 +13,22 @@ import concurrent
 import asyncio
 
 
-@pytest.mark.testgroup_edgehub_module_client
 @pytest.mark.testgroup_iothub_module_client
 @pytest.mark.callsSendEvent
-def test_module_send_event_to_iothub():
+def test_device_send_event_to_iothub():
 
-    log_message("connecting module client")
-    module_client = connections.connect_test_module_client()
+    log_message("connecting device client")
+    device_client = connections.connect_leaf_device_client()
     log_message("connecting eventhub client")
     eventhub_client = connections.connect_eventhub_client()
 
     sent_message = test_utilities.random_string_in_json()
     log_message("sending event: " + str(sent_message))
-    module_client.send_event(sent_message)
+    device_client.send_event(sent_message)
 
     log_message("wait for event to arrive at eventhub")
     received_message = eventhub_client.wait_for_next_event(
-        environment.edge_device_id,
+        environment.leaf_device_id,
         test_utilities.default_eventhub_timeout,
         expected=sent_message,
     )
@@ -38,41 +36,42 @@ def test_module_send_event_to_iothub():
         log_message("Message not received")
         assert False
 
-    log_message("disconnecting module client")
-    module_client.disconnect()
+    log_message("disconnecting device client")
+    device_client.disconnect()
     log_message("disconnecting eventhub client")
     eventhub_client.disconnect()
 
 
 @pytest.mark.asyncio
-@pytest.mark.testgroup_edgehub_module_client
 @pytest.mark.testgroup_iothub_module_client
 @pytest.mark.callsSendEvent
-async def test_module_send_event_to_iothub_async():
+async def test_device_send_event_to_iothub_async():
 
     executor = concurrent.futures.ThreadPoolExecutor()
     loop = asyncio.get_event_loop()
 
-    log_message("connecting module client")
-    module_client = await connections.connect_test_module_client_async()
+    log_message("connecting device client")
+    device_client_async = await connections.connect_leaf_device_client_async()
     log_message("connecting eventhub client")
     eventhub_client = await loop.run_in_executor(executor, connections.connect_eventhub_client)
 
     sent_message = test_utilities.random_string_in_json()
     log_message("sending event: " + str(sent_message))
-    await module_client.send_event(sent_message)
+    await device_client_async.send_event(sent_message)
 
     log_message("wait for event to arrive at eventhub")
     received_message = await loop.run_in_executor(executor, eventhub_client.wait_for_next_event,
-        environment.edge_device_id,
-        test_utilities.default_eventhub_timeout,
-        sent_message
-    )
+                               environment.leaf_device_id,
+                               test_utilities.default_eventhub_timeout,
+                               sent_message)
     if not received_message:
         log_message("Message not received")
         assert False
 
-    log_message("disconnecting module client")
-    await module_client.disconnect()
+    log_message("disconnecting device client")
+    await device_client_async.disconnect()
     log_message("disconnecting eventhub client")
     await loop.run_in_executor(executor, eventhub_client.disconnect)
+
+
+


### PR DESCRIPTION
Currently each test file has 2 tests that test sync and then async.
Connections also has 2 types of named Clients/APIs getting connected meant for the Sync Client (from Sync API) and another meant for Async Client (from Async API). This happens for both device and module.

Some abstract APIs have been included. The signature of functions in these abstract APIs have been marked with `async def` making async default . We have plans later to convert to 1 single test with 1 single client (either coming from Sync Or Async) and that 1 test will test synchronous functionality or asynchronous functionality.  When the test runs on synchronous functionality the `async def` portion would be unused.

Included the `module_under_test_has_device_wrapper` on some connect disconnect tests,