### PR TITLE
add custom logic to make the in-SDK gate yaml easier

### DIFF
--- a/ci-wrappers/csharp/Dockerfile
+++ b/ci-wrappers/csharp/Dockerfile
@@ -3,6 +3,7 @@ FROM microsoft/dotnet:2.2-sdk
 # Install system components for powershell install
 RUN apt update \
   && apt install --fix-missing -y \
+    rsync \
     vim \
     git \
     curl

--- a/vsts/templates/jobs-build-docker-image.yaml
+++ b/vsts/templates/jobs-build-docker-image.yaml
@@ -21,11 +21,18 @@ jobs:
       if ($env:ForcedImage -ne "") {
         $BuildImage="no"
       }
+      $FixedRepo=$env:Repo
+      if ($FixedRepo -like 'https://github.com/*') {
+        $FixedRepo=$FixedRepo.Substring('https://github.com/'.length)
+      }
       Write-Host "##vso[task.setvariable variable=buildImage]${BuildImage}"
+      Write-Host "##vso[task.setvariable variable=fixedRepo]${FixedRepo}"
       Write-Host "BuildImage=${BuildImage}"
+      Write-Host "fixedRepo=${FixedRepo}"
     displayName: Custom task execution logic
     env:
       ForcedImage: ${{ parameters.forced_image }}
+      Repo: ${{ parameters.repo }}
     ignoreLASTEXITCODE: false
     errorActionPreference: Stop
     failOnStderr: true
@@ -53,12 +60,13 @@ jobs:
     condition: and(succeeded(), eq(variables['buildImage'],'yes'))
 
   - script: |
-      python3 $(Horton.FrameworkRoot)/pyscripts/build_docker_image.py --language ${{ parameters.language }}  --repo ${{ parameters.repo }} --commit ${{ parameters.commit }}
+      python3 $(Horton.FrameworkRoot)/pyscripts/build_docker_image.py --language ${{ parameters.language }}  --repo ${FixedRepo}  --commit ${{ parameters.commit }}
     displayName: "build docker image ${{ parameters.language }}"
     condition: and(succeeded(), eq(variables['buildImage'],'yes'))
     env: 
       IOTHUB_E2E_REPO_ADDRESS: $(IOTHUB-E2E-REPO-ADDRESS)
       IOTHUB_E2E_REPO_USER: $(IOTHUB-E2E-REPO-USER)
       IOTHUB_E2E_REPO_PASSWORD: $(IOTHUB-E2E-REPO-PASSWORD)
+      FixedRepo: $(FixedRepo)
 
 


### PR DESCRIPTION
This change affects how we author the horton-e2e.yaml which lives in the SDK repo.  With this change, we can set Horton.Repo to $(Build.Repository.Uri), which saves us from hardcoding the repo URI into the YAML.   This is especially important for C# where we will occasionally need to run Horton builds from repos outside the Azure/ namespace.