### PR TITLE
fix script for quick-create VMs

### DIFF
--- a/scripts/colorecho.sh
+++ b/scripts/colorecho.sh
@@ -5,6 +5,7 @@
 export _cyan="1;36"
 export _red="1;31"
 export _green="1;32"
+export _yellow="1;93"
 
 function colorecho {
   color="$1"

--- a/scripts/setup-moby.sh
+++ b/scripts/setup-moby.sh
@@ -1,6 +1,10 @@
 # Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+script_dir=$(cd "$(dirname "$0")" && pwd)
+source "$script_dir/colorecho.sh"
+
+colorecho $_yellow "Checking for moby install"
 unset moby_cli_installed
 dpkg -s moby-cli | grep -q "install ok installed"
 if [ $? -eq 0 ]; then moby_cli_installed=true; fi
@@ -9,94 +13,79 @@ unset moby_engine_installed
 dpkg -s moby-engine | grep -q "install ok installed"
 if [ $? -eq 0 ]; then moby_engine_installed=true; fi
 
+need_moby=true
 if [ $moby_engine_installed ] && [ $moby_cli_installed ]; then
-  echo "moby is already installed"
-  exit 0
+  colorecho $_yellow "moby is already installed"
+  unset need_moby 
 fi
 
-unset docker_installed
-which docker > /dev/null
-if [ $? -eq 0 ]; then docker_installed=true; fi
-
-if [ $docker_installed ]; then
-  echo "docker is already installed"
-  exit 0
+if [ "$need_moby" ]; then 
+  colorecho $_yellow "checking for docker install"
+  which docker > /dev/null
+  if [ $? -eq 0 ]; then
+    colorecho $_yellow "docker is already installed"
+    unset need_moby
+  fi
 fi
 
-if [ $(lsb_release -is) != "Ubuntu" ]; then
-  echo "ERROR: This script only works on Ubunto distros"
-  exit 1
-fi
+if [ "$need_moby" ]; then 
+  if [ $(lsb_release -is) != "Ubuntu" ]; then
+    colorecho $_red "ERROR: This script only works on Ubunto distros"
+    exit 1
+  fi
 
-which curl > /dev/null
-if [ $? -ne 0 ]; then
-  sudo apt-get install -y curl
-fi
+  which curl > /dev/null
+  if [ $? -ne 0 ]; then
+    colorecho $_yellow "installing curl"
+    sudo apt-get install -y curl
+  fi
 
-# add pointers to the Microsoft APT repository
+  # add pointers to the Microsoft APT repository
 
-if [ $(lsb_release -rs) == "16.04" ]; then
-  # BEGIN 16.04-specific steps
+  colorecho $_yellow "configuring Microsoft APT repository"
   # Install repository configuration (from https://docs.microsoft.com/en-us/azure/iot-edge/how-to-install-iot-edge-linux)
-  curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > ./microsoft-prod.list
-  [ $? -eq 0 ] || { echo "curl failed"; exit 1; }
+  curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list > ./microsoft-prod.list
+  [ $? -eq 0 ] || { colorecho $_red "curl failed"; exit 1; }
   sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/
-  [ $? -eq 0 ] || { echo "sudo cp failed"; exit 1; }
+  [ $? -eq 0 ] || { colorecho $_red "sudo cp failed"; exit 1; }
 
   rm ./microsoft-prod.list
 
   # Install Microsoft GPG public key (from https://docs.microsoft.com/en-us/azure/iot-edge/how-to-install-iot-edge-linux)
   curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
-  [ $? -eq 0 ] || { echo "curl failed"; exit 1; }
+  [ $? -eq 0 ] || { colorecho $_red "curl failed"; exit 1; }
   sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/
-  [ $? -eq 0 ] || { echo "sudo cp failed"; exit 1; }
+  [ $? -eq 0 ] || { colorecho $_red "sudo cp failed"; exit 1; }
 
   rm ./microsoft.gpg
 
-  # END 16.04-specific steps
-elif [ $(lsb_release -rs) == "18.04" ]; then
-  # BEGIN 18.04-specific steps
-  # Install repository configuration (from https://docs.microsoft.com/en-us/azure/iot-edge/how-to-install-iot-edge-linux)
-  curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list > ./microsoft-prod.list
-  [ $? -eq 0 ] || { echo "curl failed"; exit 1; }
-  sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/
-  [ $? -eq 0 ] || { echo "sudo cp failed"; exit 1; }
+  # install docker engine
 
-  rm ./microsoft-prod.list
+  colorecho $_yellow "updating APT cache"
+  sudo apt-get update
+  [ $? -eq 0 ] || { colorecho $_red "apt-get update failed"; exit 1; }
 
-  # Install Microsoft GPG public key (from https://docs.microsoft.com/en-us/azure/iot-edge/how-to-install-iot-edge-linux)
-  curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
-  [ $? -eq 0 ] || { echo "curl failed"; exit 1; }
-  sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/
-  [ $? -eq 0 ] || { echo "sudo cp failed"; exit 1; }
+  colorecho $_yellow "installing moby"
+  sudo apt-get install -y moby-engine
+  [ $? -eq 0 ] || { colorecho $_red "apt-get failed"; exit 1; }
 
-  rm ./microsoft.gpg
+  sudo apt-get install -y moby-cli
+  [ $? -eq 0 ] || { colorecho $_red "apt-get failed"; exit 1; }
 
-  # END 18.04-specific steps
-else
-  echo "ERROR: this script only works with Ubuntu 16.04 and Ubuntu 18.04"
-  exit 1
+  # wait for the docker engine to start.
+  sleep 10s
 fi
-
-# install docker engine
-
-sudo apt-get update
-[ $? -eq 0 ] || { echo "apt-get update failed"; exit 1; }
-
-sudo apt-get install -y moby-engine
-[ $? -eq 0 ] || { echo "apt-get failed"; exit 1; }
-
-sudo apt-get install -y moby-cli
-[ $? -eq 0 ] || { echo "apt-get failed"; exit 1; }
-
-# wait for the docker engine to start.
-sleep 10s
 
 # add a group called 'docker' so we can add ourselves to it.  Sometimes it gets automatically created, sometimes not.
+colorecho $_yellow "creating docker group"
 sudo groupadd docker
 # allowed to fail if the group already exists
 
 # add ourselves to the docker group.  The user will have to restart the bash prompt to run docker, so we'll just
 # sudo all of our docker calls in this script.
+colorecho $_yellow "adding $USER to docker group"
 sudo usermod -aG docker $USER
-[ $? -eq 0 ] || { echo "usermod failed"; exit 1; }
+[ $? -eq 0 ] || { colorecho $_yellow "usermod failed"; exit 1; }
+
+colorecho $_green "Moby/Docker successfully installed"
+

--- a/scripts/setup-python36.sh
+++ b/scripts/setup-python36.sh
@@ -1,30 +1,52 @@
 # Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 script_dir=$(cd "$(dirname "$0")" && pwd)
+source "$script_dir/colorecho.sh"
 
 # Make sure we're running python 3.5 or higher
+colorecho $_yellow "checking for python 3.5+"
 needpython=1
 which python3 > /dev/null
 if [ $? -eq 0 ]; then
   ret=`python3 -c 'import sys; print("%i" % (sys.hexversion>0x03050000))'`
   if [ $ret -eq 1 ]; then
-    echo "Python3.5+ is already installed"
+    colorecho $_yellow "Python3.5+ is already installed"
     needpython=0
   fi
 fi
 
 if [ $needpython -eq 1 ]; then
-  sudo apt-get install -y python3 python3-pip
-  [ $? -eq 0 ] || { echo "apt-get for python3 failed"; exit 1; }
+  colorecho $_yellow "Installing python3"
+  sudo apt-get install -y python3
+  [ $? -eq 0 ] || { colorecho $_red "apt-get for python3 failed"; exit 1; }
 fi
 
+colorecho $_yellow "Checking for pip3"
+which pip3 > /dev/null
+if [ $? -ne 0 ]; then
+    colorecho $_yellow "installing pip3"
+    sudo apt-get install -y python3-pip
+  [ $? -eq 0 ] || { colorecho $_red "apt-get for python3-pip3 failed"; exit 1; }
+fi
+
+colorecho $_yellow "Installing python libraries"
 cd ${script_dir}/.. &&  \
+    python3 -m pip install --user -e horton_helpers
+if [ $? -ne 0 ]; then 
+    colorecho $_yellow "user path not accepted.  Installing globally"
     python3 -m pip install -e horton_helpers
-[ $? -eq 0 ] || { echo "install horton_helpers failed"; exit 1; }
+    [ $? -eq 0 ] || { colorecho $_red "install horton_helpers failed"; exit 1; }
+fi
 
 # install requirements for our test runner
 cd ${script_dir}/../test-runner &&  \
+    python3 -m pip install --user -r requirements.txt
+if [ $? -ne 0 ]; then 
+    colorecho $_yellow "user path not accepted.  Installing globally"
     python3 -m pip install -r requirements.txt
-[ $? -eq 0 ] || { echo "pip install requirements.txt failed"; exit 1; }
+    [ $? -eq 0 ] || { colorecho $_red "pip install requirements.txt failed"; exit 1; }
+fi
+
+colorecho $_green "Python3 and Python libraries installed successfully"
 
 

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -38,6 +38,10 @@ header $_green "\n\
 setup-ubuntu succeeded\n\
 \n\
 Please open a new bash prompt before continuing\n\
+\n\
+If you get permission errors from docker, reboot your VM\n\
+for group changes to take effect\n\
+\n\
 "
 
 


### PR DESCRIPTION
This is more than a quick script fix:
* add color output to setup_moby and setup_python
* fix case where python3 is installed but python3-pip is not installed
* fix code to add user to docker group if moby and/or docker is already installed
* add reboot recommendation to end of setup script
