### PR TITLE
remove commit name variable

### DIFF
--- a/ci-wrappers/c/Dockerfile
+++ b/ci-wrappers/c/Dockerfile
@@ -67,7 +67,6 @@ COPY ./prebuild.sh /
 RUN /prebuild.sh
 
 # phase 2: grab the code we want to test and rebuild
-ARG HORTON_COMMIT_NAME
 ARG HORTON_COMMIT_SHA
 WORKDIR /sdk
 RUN git pull

--- a/ci-wrappers/csharp/Dockerfile
+++ b/ci-wrappers/csharp/Dockerfile
@@ -38,7 +38,6 @@ COPY ./prebuild.sh /
 RUN /prebuild.sh
 
 # phase 2: grab the code we want to test and rebuild
-ARG HORTON_COMMIT_NAME
 ARG HORTON_COMMIT_SHA
 RUN git pull 
 RUN git checkout $HORTON_COMMIT_SHA

--- a/ci-wrappers/java/Dockerfile
+++ b/ci-wrappers/java/Dockerfile
@@ -27,7 +27,6 @@ COPY ./prebuild.sh /
 RUN /prebuild.sh
 
 # phase 2: grab the code we want to test and rebuild
-ARG HORTON_COMMIT_NAME
 ARG HORTON_COMMIT_SHA
 WORKDIR /sdk
 RUN git pull

--- a/ci-wrappers/node/Dockerfile.node10
+++ b/ci-wrappers/node/Dockerfile.node10
@@ -29,7 +29,6 @@ COPY ./prebuild.sh /
 RUN /prebuild.sh
 
 # phase 2: grab the code we want to test and rebuild
-ARG HORTON_COMMIT_NAME
 ARG HORTON_COMMIT_SHA
 RUN git pull 
 RUN git checkout $HORTON_COMMIT_SHA

--- a/ci-wrappers/node/Dockerfile.node6
+++ b/ci-wrappers/node/Dockerfile.node6
@@ -28,7 +28,6 @@ COPY ./prebuild.sh /
 RUN /prebuild.sh
 
 # phase 2: grab the code we want to test and rebuild
-ARG HORTON_COMMIT_NAME
 ARG HORTON_COMMIT_SHA
 WORKDIR /sdk
 RUN git pull 

--- a/ci-wrappers/node/Dockerfile.node8
+++ b/ci-wrappers/node/Dockerfile.node8
@@ -27,7 +27,6 @@ COPY ./prebuild.sh /
 RUN /prebuild.sh
 
 # phase 2: grab the code we want to test and rebuild
-ARG HORTON_COMMIT_NAME
 ARG HORTON_COMMIT_SHA
 WORKDIR /sdk
 RUN git pull 

--- a/ci-wrappers/python/Dockerfile
+++ b/ci-wrappers/python/Dockerfile
@@ -57,7 +57,6 @@ WORKDIR /wrapper
 COPY ./wrapper .
 
 # phase 2: grab the code we want to test and rebuild
-ARG HORTON_COMMIT_NAME
 ARG HORTON_COMMIT_SHA
 WORKDIR /sdk
 RUN git pull 

--- a/ci-wrappers/pythonpreview/Dockerfile.py27
+++ b/ci-wrappers/pythonpreview/Dockerfile.py27
@@ -26,7 +26,6 @@ COPY ./prebuild.sh /
 RUN /prebuild.sh
 
 # phase 2: grab the code we want to test and rebuild
-ARG HORTON_COMMIT_NAME
 ARG HORTON_COMMIT_SHA
 WORKDIR /sdk
 RUN git pull

--- a/ci-wrappers/pythonpreview/Dockerfile.py35
+++ b/ci-wrappers/pythonpreview/Dockerfile.py35
@@ -27,7 +27,6 @@ COPY ./prebuild.sh /
 RUN /prebuild.sh
 
 # phase 2: grab the code we want to test and rebuild
-ARG HORTON_COMMIT_NAME
 ARG HORTON_COMMIT_SHA
 WORKDIR /sdk
 RUN git pull 

--- a/ci-wrappers/pythonpreview/Dockerfile.py36
+++ b/ci-wrappers/pythonpreview/Dockerfile.py36
@@ -27,7 +27,6 @@ COPY ./prebuild.sh /
 RUN /prebuild.sh
 
 # phase 2: grab the code we want to test and rebuild
-ARG HORTON_COMMIT_NAME
 ARG HORTON_COMMIT_SHA
 WORKDIR /sdk
 RUN git pull

--- a/ci-wrappers/pythonpreview/Dockerfile.py37
+++ b/ci-wrappers/pythonpreview/Dockerfile.py37
@@ -26,7 +26,6 @@ COPY ./prebuild.sh /
 RUN /prebuild.sh
 
 # phase 2: grab the code we want to test and rebuild
-ARG HORTON_COMMIT_NAME
 ARG HORTON_COMMIT_SHA
 WORKDIR /sdk
 RUN git pull

--- a/pyscripts/build_docker_image.py
+++ b/pyscripts/build_docker_image.py
@@ -90,8 +90,7 @@ def build_image(tags):
     api_client = docker.APIClient(base_url="unix://var/run/docker.sock")
     build_args = {
         "HORTON_REPO": tags.repo,
-        "HORTON_COMMIT_NAME": tags.commit_name,
-        "HORTON_COMMIT_SHA": tags.commit_sha,
+        "HORTON_COMMIT_SHA": tags.commit_sha
     }
 
     if tags.image_tag_to_use_for_cache:

--- a/pyscripts/docker_tags.py
+++ b/pyscripts/docker_tags.py
@@ -9,7 +9,6 @@ from image_variants import get_default_variant
 class DockerTags:
     def __init__(self):
         self.repo = None
-        self.commit_name = None
         self.commit_sha = None
         self.langauge = None
         if running_on_azure_pipelines():
@@ -60,15 +59,6 @@ def running_on_azure_pipelines():
     return "BUILD_BUILDID" in os.environ
 
 
-def get_commit_name(commit):
-    if commit.startswith("refs/heads/"):
-        return commit.split("/")[2]
-    elif commit.startswith("refs/tags/"):
-        return commit.split("/")[2]
-    elif commit.startswith("refs/pull/"):
-        return "PR" + commit.split("/")[2]
-    else:
-        return commit
 
 
 def get_docker_tags_from_commit(language, repo, commit, variant):
@@ -79,7 +69,6 @@ def get_docker_tags_from_commit(language, repo, commit, variant):
     )
     tags.language = language
     tags.repo = repo
-    tags.commit_name = get_commit_name(commit)
     tags.commit_sha = github.get_sha_from_commit(repo, commit)
 
     default_variant = get_default_variant(language)
@@ -159,8 +148,7 @@ def get_docker_tags_from_commit(language, repo, commit, variant):
                 0,
                 "{}-{}-{}".format(
                     image_tag_prefix(),
-                    sanitize_string(tags.repo),
-                    sanitize_string(tags.commit_name),
+                    sanitize_string(tags.repo)
                 ),
             )
             # eg: pythonpreview-e2e-v3:linux-amd64-dockerV18-AzureAzureIotSdkPythonPreview-Pr59-510b1f9
@@ -169,8 +157,7 @@ def get_docker_tags_from_commit(language, repo, commit, variant):
                 "{}-{}-{}-{}".format(
                     image_tag_prefix(),
                     sanitize_string(tags.repo),
-                    sanitize_string(tags.commit_name),
-                    shorten_sha(tags.commit_sha),
+                    shorten_sha(tags.commit_sha)
                 ),
             )
 
@@ -194,8 +181,7 @@ def get_docker_tags_from_commit(language, repo, commit, variant):
                 "{}-{}-{}-{}".format(
                     image_tag_prefix(),
                     tags.variant,
-                    sanitize_string(tags.repo),
-                    sanitize_string(tags.commit_name),
+                    sanitize_string(tags.repo)
                 ),
             )
             # eg: pythonpreview-e2e-v3:linux-amd64-dockerV18-3.7.2-slim-AzureAzureIotSdkPythonPreview-Pr59-510b1f9
@@ -205,8 +191,7 @@ def get_docker_tags_from_commit(language, repo, commit, variant):
                     image_tag_prefix(),
                     tags.variant,
                     sanitize_string(tags.repo),
-                    sanitize_string(tags.commit_name),
-                    shorten_sha(tags.commit_sha),
+                    shorten_sha(tags.commit_sha)
                 ),
             )
     else:


### PR DESCRIPTION
I don't see anywhere the HORTON_COMMIT_NAME is currently being used. This PR is to remove all references to it since it seems redundant and confusing when HORTON_COMMIT_SHA exists.