### PR TITLE
[PYTHON GLUE] Updated glue to reflect messaging method refactor

### DIFF
--- a/ci-wrappers/pythonpreview/wrapper/python_glue/internal_device_glue_async.py
+++ b/ci-wrappers/pythonpreview/wrapper/python_glue/internal_device_glue_async.py
@@ -57,13 +57,13 @@ class InternalDeviceGlueAsync:
     def send_event(self, event_body):
         print("sending event")
         async_helper.run_coroutine_sync(
-            self.client.send_d2c_message(normalize_event_body(event_body))
+            self.client.send_message(normalize_event_body(event_body))
         )
         print("send confirmation received")
 
     def wait_for_c2d_message(self):
         print("Waiting for c2d message")
-        message = async_helper.run_coroutine_sync(self.client.receive_c2d_message())
+        message = async_helper.run_coroutine_sync(self.client.receive_message())
         print("Message received")
         return message_to_object(message)
 

--- a/ci-wrappers/pythonpreview/wrapper/python_glue/internal_device_glue_sync.py
+++ b/ci-wrappers/pythonpreview/wrapper/python_glue/internal_device_glue_sync.py
@@ -53,12 +53,12 @@ class InternalDeviceGlueSync:
 
     def send_event(self, event_body):
         print("sending event")
-        self.client.send_d2c_message(normalize_event_body(event_body))
+        self.client.send_message(normalize_event_body(event_body))
         print("send confirmation received")
 
     def wait_for_c2d_message(self):
         print("Waiting for c2d message")
-        message = self.client.receive_c2d_message()
+        message = self.client.receive_message()
         print("Message received")
         return message_to_object(message)
 

--- a/ci-wrappers/pythonpreview/wrapper/python_glue/internal_module_glue_async.py
+++ b/ci-wrappers/pythonpreview/wrapper/python_glue/internal_module_glue_async.py
@@ -60,7 +60,7 @@ class InternalModuleGlueAsync:
     def send_event(self, event_body):
         print("sending event")
         async_helper.run_coroutine_sync(
-            self.client.send_d2c_message(normalize_event_body(event_body))
+            self.client.send_message(normalize_event_body(event_body))
         )
         print("send confirmation received")
 

--- a/ci-wrappers/pythonpreview/wrapper/python_glue/internal_module_glue_async.py
+++ b/ci-wrappers/pythonpreview/wrapper/python_glue/internal_module_glue_async.py
@@ -67,7 +67,7 @@ class InternalModuleGlueAsync:
     def wait_for_input_message(self, input_name):
         print("Waiting for input message")
         message = async_helper.run_coroutine_sync(
-            self.client.receive_input_message(input_name)
+            self.client.receive_message_on_input(input_name)
         )
         print("Message received")
         return message_to_object(message)
@@ -117,7 +117,7 @@ class InternalModuleGlueAsync:
     def send_output_event(self, output_name, event_body):
         print("sending output event")
         async_helper.run_coroutine_sync(
-            self.client.send_to_output(normalize_event_body(event_body), output_name)
+            self.client.send_message_to_output(normalize_event_body(event_body), output_name)
         )
         print("send confirmation received")
 

--- a/ci-wrappers/pythonpreview/wrapper/python_glue/internal_module_glue_sync.py
+++ b/ci-wrappers/pythonpreview/wrapper/python_glue/internal_module_glue_sync.py
@@ -60,7 +60,7 @@ class InternalModuleGlueSync:
 
     def wait_for_input_message(self, input_name):
         print("Waiting for input message")
-        message = self.client.receive_input_message(input_name)
+        message = self.client.receive_message_on_input(input_name)
         print("Message received")
         return message_to_object(message)
 
@@ -106,7 +106,7 @@ class InternalModuleGlueSync:
 
     def send_output_event(self, output_name, event_body):
         print("sending output event")
-        self.client.send_to_output(normalize_event_body(event_body), output_name)
+        self.client.send_message_to_output(normalize_event_body(event_body), output_name)
         print("send confirmation received")
 
     def wait_for_desired_property_patch(self):

--- a/ci-wrappers/pythonpreview/wrapper/python_glue/internal_module_glue_sync.py
+++ b/ci-wrappers/pythonpreview/wrapper/python_glue/internal_module_glue_sync.py
@@ -55,7 +55,7 @@ class InternalModuleGlueSync:
 
     def send_event(self, event_body):
         print("sending event")
-        self.client.send_d2c_message(normalize_event_body(event_body))
+        self.client.send_message(normalize_event_body(event_body))
         print("send confirmation received")
 
     def wait_for_input_message(self, input_name):


### PR DESCRIPTION
Changed the glue to reflect new method names from https://github.com/Azure/azure-iot-sdk-python-preview/pull/170