### PR TITLE
update test-runner wrappers to use an object for eventBody

### DIFF
--- a/swagger/v2/parameters.json
+++ b/swagger/v2/parameters.json
@@ -78,7 +78,7 @@
     "in": "body",
     "required": true,
     "schema": {
-      "type": "string"
+      "type": "object"
     }
   }
 }

--- a/test-runner/rest_wrappers/generated/e2erestapi/operations/device_operations.py
+++ b/test-runner/rest_wrappers/generated/e2erestapi/operations/device_operations.py
@@ -298,7 +298,7 @@ class DeviceOperations(object):
         :param connection_id: Id for the connection
         :type connection_id: str
         :param event_body:
-        :type event_body: str
+        :type event_body: object
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
          deserialized response
@@ -326,7 +326,7 @@ class DeviceOperations(object):
             header_parameters.update(custom_headers)
 
         # Construct body
-        body_content = self._serialize.body(event_body, 'str')
+        body_content = self._serialize.body(event_body, 'object')
 
         # Construct and send request
         request = self._client.put(url, query_parameters)

--- a/test-runner/rest_wrappers/generated/e2erestapi/operations/module_operations.py
+++ b/test-runner/rest_wrappers/generated/e2erestapi/operations/module_operations.py
@@ -487,7 +487,7 @@ class ModuleOperations(object):
         :param connection_id: Id for the connection
         :type connection_id: str
         :param event_body:
-        :type event_body: str
+        :type event_body: object
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
          deserialized response
@@ -515,7 +515,7 @@ class ModuleOperations(object):
             header_parameters.update(custom_headers)
 
         # Construct body
-        body_content = self._serialize.body(event_body, 'str')
+        body_content = self._serialize.body(event_body, 'object')
 
         # Construct and send request
         request = self._client.put(url, query_parameters)
@@ -539,7 +539,7 @@ class ModuleOperations(object):
         :param output_name:
         :type output_name: str
         :param event_body:
-        :type event_body: str
+        :type event_body: object
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
          deserialized response
@@ -568,7 +568,7 @@ class ModuleOperations(object):
             header_parameters.update(custom_headers)
 
         # Construct body
-        body_content = self._serialize.body(event_body, 'str')
+        body_content = self._serialize.body(event_body, 'object')
 
         # Construct and send request
         request = self._client.put(url, query_parameters)

--- a/test-runner/rest_wrappers/generated/e2erestapi/operations/service_operations.py
+++ b/test-runner/rest_wrappers/generated/e2erestapi/operations/service_operations.py
@@ -259,7 +259,7 @@ class ServiceOperations(object):
         :param connection_id: Id for the connection
         :type connection_id: str
         :param event_body:
-        :type event_body: str
+        :type event_body: object
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
          deserialized response
@@ -287,7 +287,7 @@ class ServiceOperations(object):
             header_parameters.update(custom_headers)
 
         # Construct body
-        body_content = self._serialize.body(event_body, 'str')
+        body_content = self._serialize.body(event_body, 'object')
 
         # Construct and send request
         request = self._client.put(url, query_parameters)


### PR DESCRIPTION
This is the first part of a change.  Before this, messages were always strings and couldn't have attributes.  After this, I'll be able to define a message structure which will allow tests to set message attributes and serialize things that aren't strings (specifically buffers).