### PR TITLE
Disable twin desired property update test for c# - issue #1132

### DIFF
--- a/test-runner/twin_tests.py
+++ b/test-runner/twin_tests.py
@@ -130,6 +130,11 @@ class TwinTests(object):
     @pytest.mark.it("Can receive desired property patches as events")
     async def test_twin_desired_props_patch(self, client, registry):
 
+        if client.settings.language == "csharp" and (
+                client.settings.transport == "amqp" or client.settings.transport == "amqpws"
+            ):
+                pytest.skip("C#1132 twin desired property updates not received in preview service API version.")
+
         await client.enable_twin()
 
         for i in range(1, 4):


### PR DESCRIPTION
Currently, after service API version change to "2019-07-01-preview", the device client no longer receives twin desired property updates over amqp/amqpws. These tests are disabled against the following tracking issue: https://github.com/Azure/azure-iot-sdk-csharp/issues/1132