### PR TITLE
Re-enable the twin desired property update tests

### DIFF
--- a/test-runner/twin_tests.py
+++ b/test-runner/twin_tests.py
@@ -130,11 +130,6 @@ class TwinTests(object):
     @pytest.mark.it("Can receive desired property patches as events")
     async def test_twin_desired_props_patch(self, client, registry):
 
-        if client.settings.language == "csharp" and (
-                client.settings.transport == "amqp" or client.settings.transport == "amqpws"
-            ):
-                pytest.skip("C#1132 twin desired property updates not received in preview service API version.")
-
         await client.enable_twin()
 
         for i in range(1, 4):


### PR DESCRIPTION
This PR brings in the following changes:
- ~Update the .NET SDK version referenced - the Azure IoT .NET SDK now supports .NET Standard 2.1 as well~ - this has been addressed in #279 .
- Re-enable the twin desired property update tests (#253 )