### PR TITLE
Update Java wrapper to utilize new v2 APIs

### DIFF
--- a/docker_images/java/wrapper/pom.xml
+++ b/docker_images/java/wrapper/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-unit</artifactId>
-            <version>3.5.1</version>
+            <version>3.9.9</version>
         </dependency>
 
         <dependency>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.9.8</version>
+            <version>2.12.2</version>
         </dependency>
 
         <dependency>

--- a/docker_images/java/wrapper/pom.xml
+++ b/docker_images/java/wrapper/pom.xml
@@ -57,6 +57,12 @@
             <artifactId>${iot-service-client-artifact-id}</artifactId>
             <version>${iot-service-client-version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.jnr</groupId>
+            <artifactId>jnr-unixsocket</artifactId>
+            <version>0.23</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/docker_images/java/wrapper/src/main/java/glue/ModuleGlue.java
+++ b/docker_images/java/wrapper/src/main/java/glue/ModuleGlue.java
@@ -129,6 +129,8 @@ public class ModuleGlue
 
             ModuleClient client = new ModuleClient(connectionString, protocol, clientOptionsBuilder.build());
 
+            client.open(true);
+
             this._clientCount++;
             String connectionId = "moduleClient_" + this._clientCount;
             this._map.put(connectionId, client);

--- a/docker_images/java/wrapper/src/main/java/glue/ModuleGlue.java
+++ b/docker_images/java/wrapper/src/main/java/glue/ModuleGlue.java
@@ -614,6 +614,7 @@ public class ModuleGlue
             try
             {
                 client.updateReportedProperties(reportedProperties);
+                handler.handle(Future.succeededFuture());
             }
             catch (TimeoutException | InterruptedException e)
             {

--- a/docker_images/java/wrapper/src/main/java/glue/ModuleGlue.java
+++ b/docker_images/java/wrapper/src/main/java/glue/ModuleGlue.java
@@ -359,8 +359,8 @@ public class ModuleGlue
         else
         {
             EventCallback callback = new EventCallback(handler);
-            System.out.printf("calling sendTelemetryAsync%n");
-            client.sendTelemetryAsync(msg, callback, null);
+            System.out.printf("calling sendEventAsync%n");
+            client.sendEventAsync(msg, callback, null);
         }
     }
 

--- a/docker_images/java/wrapper/src/main/java/glue/ModuleGlue.java
+++ b/docker_images/java/wrapper/src/main/java/glue/ModuleGlue.java
@@ -312,7 +312,7 @@ public class ModuleGlue
         {
             try
             {
-                System.out.println("calling startTwin");
+                System.out.println("calling subscribeToDesiredProperties to start twin");
                 client.subscribeToDesiredProperties(
                     (twin, context) ->
                     {
@@ -323,6 +323,8 @@ public class ModuleGlue
                         }
                     },
                     null);
+
+                handler.handle(Future.succeededFuture());
             }
             catch (TimeoutException | InterruptedException e)
             {

--- a/docker_images/java/wrapper/src/main/java/glue/UnixDomainSocketChannelImpl.java
+++ b/docker_images/java/wrapper/src/main/java/glue/UnixDomainSocketChannelImpl.java
@@ -18,6 +18,7 @@ public class UnixDomainSocketChannelImpl implements UnixDomainSocketChannel
     @Override
     public void open(String address) throws IOException
     {
+        System.out.printf("Opening unix domain socket for address %s%n", address);
         this.unixSocketAddress = new UnixSocketAddress(address);
         this.channel = UnixSocketChannel.open(this.unixSocketAddress);
     }
@@ -25,6 +26,9 @@ public class UnixDomainSocketChannelImpl implements UnixDomainSocketChannel
     @Override
     public void write(byte[] output) throws IOException
     {
+        String writeContents = new String(output.clone());
+        System.out.println("Writing content to unix domain socket:");
+        System.out.println(writeContents);
         this.channel.write(ByteBuffer.wrap(output));
     }
 
@@ -34,12 +38,18 @@ public class UnixDomainSocketChannelImpl implements UnixDomainSocketChannel
         ByteBuffer inputByteBuffer = ByteBuffer.wrap(inputBuffer);
         int bytesRead = this.channel.read(inputByteBuffer);
         System.arraycopy(inputByteBuffer.array(), 0, inputBuffer, 0, inputByteBuffer.capacity());
+
+        String readContents = new String(inputBuffer.clone());
+        System.out.println("Read content from unix domain socket:");
+        System.out.println(readContents);
+
         return bytesRead;
     }
 
     @Override
     public void close() throws IOException
     {
+        System.out.println("Closing unix domain socket");
         this.channel.close();
     }
 }

--- a/docker_images/java/wrapper/src/main/java/glue/UnixDomainSocketChannelImpl.java
+++ b/docker_images/java/wrapper/src/main/java/glue/UnixDomainSocketChannelImpl.java
@@ -12,23 +12,17 @@ import java.nio.ByteBuffer;
 
 public class UnixDomainSocketChannelImpl implements UnixDomainSocketChannel
 {
-    UnixSocketAddress unixSocketAddress;
-    UnixSocketChannel channel;
+    private UnixSocketChannel channel;
 
     @Override
     public void open(String address) throws IOException
     {
-        System.out.printf("Opening unix domain socket for address %s%n", address);
-        this.unixSocketAddress = new UnixSocketAddress(address);
-        this.channel = UnixSocketChannel.open(this.unixSocketAddress);
+        this.channel = UnixSocketChannel.open(new UnixSocketAddress(address));
     }
 
     @Override
     public void write(byte[] output) throws IOException
     {
-        String writeContents = new String(output.clone());
-        System.out.println("Writing content to unix domain socket:");
-        System.out.println(writeContents);
         this.channel.write(ByteBuffer.wrap(output));
     }
 
@@ -38,19 +32,12 @@ public class UnixDomainSocketChannelImpl implements UnixDomainSocketChannel
         ByteBuffer inputByteBuffer = ByteBuffer.wrap(inputBuffer);
         int bytesRead = this.channel.read(inputByteBuffer);
         System.arraycopy(inputByteBuffer.array(), 0, inputBuffer, 0, inputByteBuffer.capacity());
-
-        String readContents = new String(inputBuffer.clone());
-        System.out.println("Read " + bytesRead + " bytes from unix domain socket");
-        System.out.println("Read content from unix domain socket:");
-        System.out.println(readContents);
-
         return bytesRead;
     }
 
     @Override
     public void close() throws IOException
     {
-        System.out.println("Closing unix domain socket");
         this.channel.close();
     }
 }

--- a/docker_images/java/wrapper/src/main/java/glue/UnixDomainSocketChannelImpl.java
+++ b/docker_images/java/wrapper/src/main/java/glue/UnixDomainSocketChannelImpl.java
@@ -40,6 +40,7 @@ public class UnixDomainSocketChannelImpl implements UnixDomainSocketChannel
         System.arraycopy(inputByteBuffer.array(), 0, inputBuffer, 0, inputByteBuffer.capacity());
 
         String readContents = new String(inputBuffer.clone());
+        System.out.println("Read " + bytesRead + " bytes from unix domain socket");
         System.out.println("Read content from unix domain socket:");
         System.out.println(readContents);
 

--- a/docker_images/java/wrapper/src/main/java/glue/UnixDomainSocketChannelImpl.java
+++ b/docker_images/java/wrapper/src/main/java/glue/UnixDomainSocketChannelImpl.java
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package glue;
+
+import com.microsoft.azure.sdk.iot.device.hsm.UnixDomainSocketChannel;
+import jnr.unixsocket.UnixSocketAddress;
+import jnr.unixsocket.UnixSocketChannel;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class UnixDomainSocketChannelImpl implements UnixDomainSocketChannel
+{
+    UnixSocketAddress unixSocketAddress;
+    UnixSocketChannel channel;
+
+    @Override
+    public void open(String address) throws IOException
+    {
+        this.unixSocketAddress = new UnixSocketAddress(address);
+        this.channel = UnixSocketChannel.open(this.unixSocketAddress);
+    }
+
+    @Override
+    public void write(byte[] output) throws IOException
+    {
+        this.channel.write(ByteBuffer.wrap(output));
+    }
+
+    @Override
+    public int read(byte[] inputBuffer) throws IOException
+    {
+        ByteBuffer inputByteBuffer = ByteBuffer.wrap(inputBuffer);
+        int bytesRead = this.channel.read(inputByteBuffer);
+        System.arraycopy(inputByteBuffer.array(), 0, inputBuffer, 0, inputByteBuffer.capacity());
+        return bytesRead;
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        this.channel.close();
+    }
+}


### PR DESCRIPTION
Java v2 has made a number of breaking changes including renaming and re-designing module client APIs. This brings the latest Java module client code to the Java wrapper.

The v2 Java code has not been released yet, so this PR can't be checked in yet