### PR TITLE
upgrade some java wrapper dependencies

### DIFF
--- a/docker_images/java/wrapper/pom.xml
+++ b/docker_images/java/wrapper/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-unit</artifactId>
-            <version>4.2.3</version>
+            <version>3.9.9</version>
         </dependency>
 
         <dependency>

--- a/docker_images/java/wrapper/pom.xml
+++ b/docker_images/java/wrapper/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-unit</artifactId>
-            <version>3.5.1</version>
+            <version>4.2.3</version>
         </dependency>
 
         <dependency>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.9.8</version>
+            <version>2.12.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
vertx and jackson libraries were getting flagged for component governance issues, and they also may be interfering with the Java library's attempt to upgrade related libraries.