### PR TITLE
Upgrade oauth dependency to 3.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ colorama
 docker; sys_platform != 'win32' # we don't use it on Windows.  Exclude it to avoid CVE-2021-32559
 junitparser==1.4.1
 msrest
-oauthlib==3.2.1
+oauthlib>=3.2.1 # >= 3.2.1 because of CVE-2022-36087. If MSRest gets an update that increments the oauthlib dependency version up above 3.2.1, then this line can be deleted
 pre-commit
 pytest
 pytest-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ colorama
 docker; sys_platform != 'win32' # we don't use it on Windows.  Exclude it to avoid CVE-2021-32559
 junitparser==1.4.1
 msrest
-oauthlib>=3.2.1 # >= 3.2.1 because of CVE-2022-36087. If MSRest gets an update that increments the oauthlib dependency version up above 3.2.1, then this line can be deleted
+oauthlib>=3.2.1 # >= 3.2.1 because of CVE-2022-36087. If MSRest gets an update that increments the oauthlib dependency version up to at least 3.2.1, then this line can be deleted
 pre-commit
 pytest
 pytest-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ colorama
 docker; sys_platform != 'win32' # we don't use it on Windows.  Exclude it to avoid CVE-2021-32559
 junitparser==1.4.1
 msrest
+oauthlib==3.2.1
 pre-commit
 pytest
 pytest-asyncio


### PR DESCRIPTION
The latest MSrest package pulls in oauthlib 3.2.0 which has a security vulnerability. This change overrides that version to use a version of oauthlib that fixes this vulnerability.