### PR TITLE
Fix CVE-2022-40899

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ uamqp
 urllib3
 PyYAML
 inflection==0.5.0
+future>=0.18.3 # >= 0.18.3 because CVE-2022-40899 affects versions 0.18.2 and below


### PR DESCRIPTION
"An issue discovered in Python Charmers Future 0.18.2 and earlier allows remote attackers to cause a denial of service via crafted Set-Cookie header from malicious web server. This issue has been patched in version 0.18.3."