### PR TITLE
Fix version of Java e2e tests dependency

### DIFF
--- a/docker_images/java/wrapper/pom.xml
+++ b/docker_images/java/wrapper/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.microsoft.azure.sdk.iot</groupId>
         <artifactId>iot-e2e-tests</artifactId>
-        <version>0.26.0</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
We unified all these non-release pom files to use 1.0.0 moving forward