### PR TITLE
Resolve azure_macro_utils includes via SDK build dir, not deps source tree

### DIFF
--- a/docker_images/c/wrapper/CMakeLists.txt
+++ b/docker_images/c/wrapper/CMakeLists.txt
@@ -23,6 +23,15 @@ include_directories(${SHARED_UTIL_INC_FOLDER})
 include_directories(${IOTHUB_SERVICE_CLIENT_INC_FOLDER})
 include_directories(${IOTHUB_CLIENT_INC_FOLDER})
 include_directories("${PROJECT_SOURCE_DIR}/deps/restbed/source")
+# The SDK's public headers still #include "azure_macro_utils/macro_utils.h",
+# but the migrated macro-utils-c submodule only ships headers under "macro_utils/".
+# The SDK bridges this by generating forwarding headers into its build tree
+# (${CMAKE_BINARY_DIR}/azure_macro_utils/...) and adding ${CMAKE_BINARY_DIR} to
+# its own targets' include path. Because this wrapper builds edge_e2e_rest_server
+# in the top-level CMake scope - where the SDK's directory-scoped include path
+# does not reach - it must add that same generated-header directory itself so the
+# legacy "azure_macro_utils/..." includes used by the SDK headers resolve here too.
+include_directories(${CMAKE_BINARY_DIR})
 # MACRO_UTILS_INC_FOLDER is no longer set by the new macro-utils-c CMakeLists.txt;
 # keep it as a fallback for older SDK versions that still define the variable.
 include_directories(${MACRO_UTILS_INC_FOLDER})


### PR DESCRIPTION
The Horton C E2E wrapper (edge_e2e_rest_server) failed to build with:

    iothub_client_edge.h: fatal error:
        azure_macro_utils/macro_utils.h: No such file or directory

Root cause: the macro-utils-c migration switched the SDK submodule to Azure/macro-utils-c, which ships headers under macro_utils/. The SDK's public headers still include "azure_macro_utils/macro_utils.h" and bridge this by generating forwarding headers into its own build tree (CMAKE_BINARY_DIR/azure_macro_utils/...), exposed to the SDK's targets via a directory-scoped include_directories(CMAKE_BINARY_DIR). That scope does not reach this wrapper, which builds its target in the top-level scope.

Fix: add CMAKE_BINARY_DIR to the wrapper's include path. Because the SDK is pulled in via add_subdirectory, both share one build tree, so the SDK's existing forwarding shim resolves the legacy azure_macro_utils/... includes for the wrapper's target too.

This keeps the workaround in the consumer instead of having the SDK emit forwarding headers into the vendored deps/azure-macro-utils-c source tree, avoiding mutation of a submodule checkout.