### PR TITLE
Fix flaky CI failures: docker login retry, GitHub SHA retry, twin patch reconnect

### DIFF
--- a/docker_images/c/wrapper/CMakeLists.txt
+++ b/docker_images/c/wrapper/CMakeLists.txt
@@ -23,6 +23,15 @@ include_directories(${SHARED_UTIL_INC_FOLDER})
 include_directories(${IOTHUB_SERVICE_CLIENT_INC_FOLDER})
 include_directories(${IOTHUB_CLIENT_INC_FOLDER})
 include_directories("${PROJECT_SOURCE_DIR}/deps/restbed/source")
+# The SDK's public headers still #include "azure_macro_utils/macro_utils.h",
+# but the migrated macro-utils-c submodule only ships headers under "macro_utils/".
+# The SDK bridges this by generating forwarding headers into its build tree
+# (${CMAKE_BINARY_DIR}/azure_macro_utils/...) and adding ${CMAKE_BINARY_DIR} to
+# its own targets' include path. Because this wrapper builds edge_e2e_rest_server
+# in the top-level CMake scope - where the SDK's directory-scoped include path
+# does not reach - it must add that same generated-header directory itself so the
+# legacy "azure_macro_utils/..." includes used by the SDK headers resolve here too.
+include_directories(${CMAKE_BINARY_DIR})
 # MACRO_UTILS_INC_FOLDER is no longer set by the new macro-utils-c CMakeLists.txt;
 # keep it as a fallback for older SDK versions that still define the variable.
 include_directories(${MACRO_UTILS_INC_FOLDER})

--- a/test-runner/twin_tests.py
+++ b/test-runner/twin_tests.py
@@ -139,14 +139,29 @@ class TwinTests(object):
         for i in range(1, 4):
             twin_sent = sample_content.make_desired_props()
 
-            # Keep a single wait future alive and re-send the patch on
-            # timeout.  Cancelling the REST call would leave an orphaned
-            # handler thread on the wrapper that consumes subsequent
-            # patches from the queue.  Total retry budget (max_send_attempts
-            # * send_interval) must stay below default_api_timeout (150s)
-            # or the underlying HTTP read_timeout will kill the future.
-            max_send_attempts = 3
-            send_interval = 45
+            # A single long-poll wait_for_desired_property_patch is kept alive
+            # for the whole patch.  Cancelling it would orphan a wrapper-side
+            # handler thread that then swallows the next patch from the queue.
+            # Because that long-poll is bounded by default_api_timeout (150s),
+            # the entire send/recover schedule below must stay under 150s.
+            #
+            # Recovery strategy when a patch does not arrive:
+            #   - A successful get_twin() only proves the module<->EdgeHub twin
+            #     channel.  Desired-property *delivery* additionally requires
+            #     EdgeHub's cloud-side MessagingServiceClient to finish setting
+            #     up its upstream subscription, which can legitimately take
+            #     ~45s.  So the first attempt waits the longest to give a
+            #     merely-slow proxy time to come online.
+            #   - If that long wait still yields nothing, the cloud proxy is
+            #     wedged rather than slow.  Re-issuing enable_twin from the
+            #     module is a no-op once the twin feature is enabled, so it
+            #     cannot help.  Instead we disconnect/reconnect the module:
+            #     EdgeHub tears the MessagingServiceClient down on disconnect
+            #     (lazily) and rebuilds it on reconnect, giving the upstream
+            #     desired-property subscription a fresh start.  connection_id is
+            #     preserved across disconnect2/connect2, so the pending
+            #     long-poll keeps reading from the same queue.
+            wait_schedule = [45, 30, 30]  # 105s of waits + 2 reconnects < 150s
 
             logger("start waiting for patch {}".format(i))
             patch_future = asyncio.ensure_future(
@@ -156,14 +171,22 @@ class TwinTests(object):
             )
             await asyncio.sleep(3)  # wait for async call to take effect
 
-            for attempt in range(max_send_attempts):
+            for attempt, wait_interval in enumerate(wait_schedule):
+                if attempt > 0:
+                    # Patch was not delivered on the previous attempt; rebuild
+                    # EdgeHub's cloud proxy by reconnecting before resending.
+                    logger("patch {} not received, reconnecting to rebuild EdgeHub cloud proxy".format(i))
+                    await client.disconnect2()
+                    await connect2_with_retry(client)
+                    await client.enable_twin()
+
                 logger("sending patch {} (attempt {})".format(i, attempt + 1))
                 await patch_desired_props(registry, client, twin_sent)
                 logger("patch {} sent".format(i))
 
                 try:
                     await asyncio.wait_for(
-                        asyncio.shield(patch_future), timeout=send_interval
+                        asyncio.shield(patch_future), timeout=wait_interval
                     )
                     logger("patch {} received".format(i))
                     break
@@ -172,15 +195,15 @@ class TwinTests(object):
                         patch_future.result()  # propagate if it failed
                         logger("patch {} received (late)".format(i))
                         break
-                    if attempt < max_send_attempts - 1:
-                        logger("patch {} not received after {}s, resending".format(i, send_interval))
+                    if attempt < len(wait_schedule) - 1:
+                        logger("patch {} not received after {}s".format(i, wait_interval))
                     else:
                         patch_future.cancel()
                         try:
                             await patch_future
                         except (asyncio.CancelledError, Exception):
                             pass
-                        assert False, "Timed out waiting for desired property patch {} after {} send attempts".format(i, max_send_attempts)
+                        assert False, "Timed out waiting for desired property patch {} after {} send attempts".format(i, len(wait_schedule))
 
     @pytest.mark.it(
         "Can set reported properties which can be successfully retrieved by the service"

--- a/vsts/templates/steps-build-docker-image.yaml
+++ b/vsts/templates/steps-build-docker-image.yaml
@@ -165,7 +165,22 @@ steps:
       )
 
 - bash: |
-    docker login -u ${{ parameters.repo_user }} -p ${{ parameters.repo_password }} ${{ parameters.repo_address }} 
+    # docker login to ACR can transiently time out ("request canceled while
+    # waiting for connection").  Retry with backoff so a single network blip
+    # does not fail the whole job.
+    retry() {
+      local max=5 delay=10 n=1
+      until "$@"; do
+        if [ "$n" -ge "$max" ]; then
+          echo "Command failed after $n attempts." >&2
+          return 1
+        fi
+        echo "Attempt $n failed. Retrying in ${delay}s..." >&2
+        sleep "$delay"
+        n=$((n + 1))
+      done
+    }
+    retry docker login -u ${{ parameters.repo_user }} -p ${{ parameters.repo_password }} ${{ parameters.repo_address }}
   displayName: 'docker login'
   condition: and(succeeded(), eq(variables['buildImage'],'yes'))
 
@@ -188,7 +203,29 @@ steps:
     NODE_BRANCH="main"
 
     echo "Resolving commit SHA for ${NODE_REPO} @ ${NODE_BRANCH}..."
-    COMMIT_SHA=$(curl -sf "https://api.github.com/repos/${NODE_REPO}/git/refs/heads/${NODE_BRANCH}" | python3 -c "import sys,json; print(json.load(sys.stdin)['object']['sha'])")
+    # The GitHub API call can transiently fail or be rate-limited, returning a
+    # non-JSON (or empty) body that crashes json.load.  Retry with backoff and
+    # use an auth token when available to raise the rate limit.
+    AUTH_HEADER=()
+    if [ -n "${GITHUB_TOKEN}" ]; then
+      AUTH_HEADER=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+    fi
+    COMMIT_SHA=""
+    for attempt in 1 2 3 4 5; do
+      RESPONSE=$(curl -s "${AUTH_HEADER[@]}" "https://api.github.com/repos/${NODE_REPO}/git/refs/heads/${NODE_BRANCH}" || true)
+      COMMIT_SHA=$(echo "${RESPONSE}" | python3 -c "import sys,json; print(json.load(sys.stdin)['object']['sha'])" 2>/dev/null || true)
+      if [ -n "${COMMIT_SHA}" ]; then
+        break
+      fi
+      echo "Attempt ${attempt}: could not resolve commit SHA. Response was:" >&2
+      echo "${RESPONSE}" | head -c 500 >&2
+      echo "" >&2
+      sleep $((attempt * 10))
+    done
+    if [ -z "${COMMIT_SHA}" ]; then
+      echo "ERROR: failed to resolve commit SHA for ${NODE_REPO} @ ${NODE_BRANCH} after 5 attempts." >&2
+      exit 1
+    fi
     echo "Commit SHA: ${COMMIT_SHA}"
 
     echo "Building ${IMAGE_NAME}..."

--- a/vsts/templates/steps-pre-test.yaml
+++ b/vsts/templates/steps-pre-test.yaml
@@ -16,9 +16,24 @@ steps:
   condition: and(succeeded(), ne(variables['skipTest'],'yes'), eq(variables['deploymentType'], 'iotedge'))
 
 - bash: |
-    docker login -u ${{ parameters.repo_user }} -p ${{ parameters.repo_password }} ${{ parameters.repo_address }} 
+    # docker login to ACR can transiently time out ("request canceled while
+    # waiting for connection").  Retry with backoff so a single network blip
+    # does not fail the whole job.
+    retry() {
+      local max=5 delay=10 n=1
+      until "$@"; do
+        if [ "$n" -ge "$max" ]; then
+          echo "Command failed after $n attempts: $1" >&2
+          return 1
+        fi
+        echo "Attempt $n failed. Retrying in ${delay}s..." >&2
+        sleep "$delay"
+        n=$((n + 1))
+      done
+    }
+    retry docker login -u ${{ parameters.repo_user }} -p ${{ parameters.repo_password }} ${{ parameters.repo_address }}
     if [ $(which sudo) ]; then 
-      sudo docker login -u ${{ parameters.repo_user }} -p ${{ parameters.repo_password }} ${{ parameters.repo_address }} 
+      retry sudo docker login -u ${{ parameters.repo_user }} -p ${{ parameters.repo_password }} ${{ parameters.repo_address }}
     fi
   displayName: 'docker login'
   condition: and(succeeded(), ne(variables['skipTest'],'yes'), eq(variables['usesDocker'], 'yes'))


### PR DESCRIPTION
Three transient/timing flakes observed in horton-gate-build:

- docker login to ACR: add retry with backoff (transient connection timeouts)

- default-friend-module GitHub SHA resolution: retry + tolerate non-JSON/rate-limited responses

- test_twin_desired_props_patch: reconnect (disconnect2/connect2) between resends to rebuild EdgeHub's cloud proxy / upstream twin subscription, instead of a no-op enable_twin re-subscribe; tuned within the 150s long-poll budget