### PR TITLE
Disable component governance on horton pipelines

### DIFF
--- a/vsts/templates/steps-create-azure-resources.yaml
+++ b/vsts/templates/steps-create-azure-resources.yaml
@@ -23,3 +23,10 @@ steps:
   artifact: test_config
   displayName: Publish artifact (test config)
   condition: always()
+
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: 'Component Detection'
+  inputs:
+    alertWarningLevel: Never
+    # This pipeline uses packages that may not be included in shipped packages, so do not file component governance alerts for out-of-date components. Component governance is
+    # still run in CI pipelines to catch component governance issues in shipped packages.

--- a/vsts/templates/steps-destroy-azure-resources.yaml
+++ b/vsts/templates/steps-destroy-azure-resources.yaml
@@ -17,3 +17,10 @@ steps:
       az group delete --name $AZURE_RESOURCE_GROUP --yes --no-wait
   displayName: Destroy Azure Resource Group
   condition: always()
+
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: 'Component Detection'
+  inputs:
+    alertWarningLevel: Never
+    # This pipeline uses packages that may not be included in shipped packages, so do not file component governance alerts for out-of-date components. Component governance is
+    # still run in CI pipelines to catch component governance issues in shipped packages.

--- a/vsts/templates/steps-post-test.yaml
+++ b/vsts/templates/steps-post-test.yaml
@@ -37,4 +37,9 @@ steps:
     IOTHUB_E2E_CONNECTION_STRING: $(IOTHUB-E2E-CONNECTION-STRING)
   condition: and(always(), ne(variables['skipTest'],'yes'))
 
-
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: 'Component Detection'
+  inputs:
+    alertWarningLevel: Never
+    # This pipeline uses packages that may not be included in shipped packages, so do not file component governance alerts for out-of-date components. Component governance is
+    # still run in CI pipelines to catch component governance issues in shipped packages.


### PR DESCRIPTION
Component governance is useful for finding vulnerable dependencies in the bits we ship, but we do not ship these horton bits