### PR TITLE
Add scheduled pipeline to clean up leftover Azure resource groups

### DIFF
--- a/scripts/Azure.Iot.Sdk.Test.psm1
+++ b/scripts/Azure.Iot.Sdk.Test.psm1
@@ -1246,10 +1246,32 @@ function Add-DpsX509EnrollmentGroup {
 }
 
 # <[Azure DPS Helper Functions]>
+function Get-AzureResourceGroupNamePrefix {
+    <#
+    .SYNOPSIS
+    Returns the resource group name prefix used by this repository's pipelines.
+
+    .DESCRIPTION
+    Every resource group created by this framework is named "<prefix><guid>". The prefix is
+    intentionally unique to this repository so that the scheduled cleanup pipeline in
+    vsts/cleanup-leftover-resources.yaml can safely identify and delete ONLY the resource groups
+    created by these pipelines. This is the single source of truth for the prefix; both
+    resource-group creation and the cleanup rely on it, so do not fork this value.
+    #>
+    return "rg-iot-sdk-e2e-"
+}
+
 function New-AzureResourceGroupName {
-    param([string]$Prefix = "rg-", [string]$OutFile = $null)
+    param([string]$Prefix = $(Get-AzureResourceGroupNamePrefix), [string]$OutFile = $null)
+
+    # Azure resource group names may be at most 90 characters long.
+    $MaxResourceGroupNameLength = 90
 
     $ResourceGroupName = $Prefix + $(New-GuidString -NoDashes)
+
+    if ($ResourceGroupName.Length -gt $MaxResourceGroupNameLength) {
+        $ResourceGroupName = $ResourceGroupName.Substring(0, $MaxResourceGroupNameLength)
+    }
 
     if (-not [string]::IsNullOrWhiteSpace($OutFile)) {
         $OutFileDir = Split-Path -Path $OutFile -Parent
@@ -1262,6 +1284,130 @@ function New-AzureResourceGroupName {
     }
 
     return $ResourceGroupName
+}
+
+function Remove-LeftoverAzureResourceGroups {
+    <#
+    .SYNOPSIS
+    Deletes resource groups created by this repository's pipelines that are older than a threshold.
+
+    .DESCRIPTION
+    Finds every resource group whose name starts with the prefix returned by
+    Get-AzureResourceGroupNamePrefix (i.e. only the resource groups created by this framework's
+    pipelines) and deletes those whose 'CreatedOn' tag shows they were created more than
+    -MinimumAgeHours hours ago. Resource groups created within the last -MinimumAgeHours hours are
+    left untouched so that in-progress pipeline runs are never disturbed. Resource groups without a
+    parseable 'CreatedOn' tag are skipped, because their age cannot be determined safely.
+
+    Deletions are issued with '--no-wait'; this function returns after queuing them.
+
+    .PARAMETER MinimumAgeHours
+    Minimum age, in hours, a resource group must have before it is eligible for deletion. Resource
+    groups created this many hours ago or less are kept. Default is 3.
+
+    .EXAMPLE
+    PS> Remove-LeftoverAzureResourceGroups -MinimumAgeHours 3
+
+    Deletes matching resource groups older than 3 hours.
+
+    .EXAMPLE
+    PS> Remove-LeftoverAzureResourceGroups -WhatIf
+
+    Lists the resource groups that would be deleted without deleting them.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param(
+        [int]$MinimumAgeHours = 3
+    )
+
+    $Prefix = Get-AzureResourceGroupNamePrefix
+    $Now = (Get-Date).ToUniversalTime()
+    $Cutoff = $Now.AddHours(-$MinimumAgeHours)
+
+    Write-Host "Cleanup run (UTC)     : $($Now.ToString('o'))"
+    Write-Host "Resource group prefix : '$Prefix'"
+    Write-Host "Minimum age to delete : $MinimumAgeHours hour(s) (delete when created at or before $($Cutoff.ToString('o')))"
+
+    $RawJson = az group list --query "[].{name:name, createdOn:tags.CreatedOn, runUrl:tags.AzDevOpsRunUrl}" -o json --only-show-errors
+    Stop-OnError -Step "List Azure resource groups" -Throw
+
+    $Groups = @($RawJson | ConvertFrom-Json | Where-Object {
+        $_.name -and $_.name.StartsWith($Prefix, [System.StringComparison]::OrdinalIgnoreCase)
+    })
+
+    Write-Host "Found $($Groups.Count) resource group(s) matching prefix '$Prefix'."
+
+    $Deleted = [System.Collections.Generic.List[string]]::new()
+    $Skipped = [System.Collections.Generic.List[string]]::new()
+    $Failed  = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($Group in $Groups) {
+        $Name = $Group.name
+        $CreatedOnValue = $Group.createdOn
+
+        if ($null -eq $CreatedOnValue -or [string]::IsNullOrWhiteSpace([string]$CreatedOnValue)) {
+            Write-Host "SKIP   $Name : no 'CreatedOn' tag; age cannot be determined."
+            $Skipped.Add($Name)
+            continue
+        }
+
+        # ConvertFrom-Json parses the ISO-8601 'CreatedOn' tag (which always carries a UTC offset)
+        # into a [datetime], so normalize whatever type we received back to a UTC instant.
+        $CreatedOn = $null
+        try {
+            if ($CreatedOnValue -is [datetimeoffset]) {
+                $CreatedOn = $CreatedOnValue.UtcDateTime
+            } elseif ($CreatedOnValue -is [datetime]) {
+                $CreatedOn = ([datetimeoffset]$CreatedOnValue).UtcDateTime
+            } else {
+                $CreatedOn = [datetimeoffset]::Parse(
+                    [string]$CreatedOnValue,
+                    [System.Globalization.CultureInfo]::InvariantCulture,
+                    [System.Globalization.DateTimeStyles]::AssumeUniversal).UtcDateTime
+            }
+        } catch {
+            Write-Host "SKIP   $Name : unparseable 'CreatedOn' tag value '$CreatedOnValue'."
+            $Skipped.Add($Name)
+            continue
+        }
+
+        $CreatedOnDisplay = $CreatedOn.ToString('o')
+        $AgeHours = [math]::Round(($Now - $CreatedOn).TotalHours, 2)
+
+        if ($CreatedOn -ge $Cutoff) {
+            Write-Host "SKIP   $Name : age $AgeHours h is within the $MinimumAgeHours h threshold (created $CreatedOnDisplay)."
+            $Skipped.Add($Name)
+            continue
+        }
+
+        $RunUrl = if ([string]::IsNullOrWhiteSpace($Group.runUrl)) { "(unknown run)" } else { $Group.runUrl }
+
+        if (-not $PSCmdlet.ShouldProcess($Name, "Delete resource group (age $AgeHours h; $RunUrl)")) {
+            $Skipped.Add($Name)
+            continue
+        }
+
+        Write-Host "DELETE $Name : age $AgeHours h exceeds $MinimumAgeHours h (created $CreatedOnDisplay; $RunUrl)."
+        az group delete --name $Name --yes --no-wait --only-show-errors | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Failed to queue deletion of $Name (az exit code $LASTEXITCODE)."
+            $Failed.Add($Name)
+        } else {
+            $Deleted.Add($Name)
+        }
+    }
+
+    Write-Host ""
+    Write-Host "==== Cleanup summary ===="
+    Write-Host "Queued for deletion        : $($Deleted.Count)"
+    Write-Host "Skipped (too new / no tag) : $($Skipped.Count)"
+    Write-Host "Failed to queue            : $($Failed.Count)"
+    if ($Deleted.Count -gt 0) { Write-Host "Deleted: $($Deleted -join ', ')" }
+    if ($Failed.Count -gt 0)  { Write-Host "Failed : $($Failed -join ', ')" }
+
+    if ($Failed.Count -gt 0) {
+        throw "$($Failed.Count) resource group deletion(s) could not be queued."
+    }
 }
 
 
@@ -3234,7 +3380,9 @@ function Test-SubmoduleConsistency {
 Export-ModuleMember -Function Debug-PSScript
 Export-ModuleMember -Function Invoke-Script
 Export-ModuleMember -Function Set-FileContent
+Export-ModuleMember -Function Get-AzureResourceGroupNamePrefix
 Export-ModuleMember -Function New-AzureResourceGroupName
+Export-ModuleMember -Function Remove-LeftoverAzureResourceGroups
 Export-ModuleMember -Function New-AzIotTestEnvironment
 Export-ModuleMember -Function Get-AzIotTestEnvironment
 Export-ModuleMember -Function ConvertFrom-JsonToTestEnvironmentInfo

--- a/scripts/Azure.Iot.Sdk.Test.psm1
+++ b/scripts/Azure.Iot.Sdk.Test.psm1
@@ -1292,14 +1292,19 @@ function Remove-LeftoverAzureResourceGroups {
     Deletes resource groups created by this repository's pipelines that are older than a threshold.
 
     .DESCRIPTION
-    Finds every resource group whose name starts with the prefix returned by
-    Get-AzureResourceGroupNamePrefix (i.e. only the resource groups created by this framework's
+    Finds every resource group whose name starts with -Prefix (which defaults to the value returned
+    by Get-AzureResourceGroupNamePrefix, i.e. only the resource groups created by this framework's
     pipelines) and deletes those whose 'CreatedOn' tag shows they were created more than
     -MinimumAgeHours hours ago. Resource groups created within the last -MinimumAgeHours hours are
     left untouched so that in-progress pipeline runs are never disturbed. Resource groups without a
     parseable 'CreatedOn' tag are skipped, because their age cannot be determined safely.
 
     Deletions are issued with '--no-wait'; this function returns after queuing them.
+
+    .PARAMETER Prefix
+    Resource group name prefix to match. Defaults to Get-AzureResourceGroupNamePrefix (this
+    repository's prefix). Another repository that reuses this function should pass the prefix its
+    own pipelines use, so that only its resource groups are considered for deletion.
 
     .PARAMETER MinimumAgeHours
     Minimum age, in hours, a resource group must have before it is eligible for deletion. Resource
@@ -1317,10 +1322,10 @@ function Remove-LeftoverAzureResourceGroups {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
+        [string]$Prefix = $(Get-AzureResourceGroupNamePrefix),
         [int]$MinimumAgeHours = 3
     )
 
-    $Prefix = Get-AzureResourceGroupNamePrefix
     $Now = (Get-Date).ToUniversalTime()
     $Cutoff = $Now.AddHours(-$MinimumAgeHours)
 

--- a/vsts/cleanup-leftover-resources.yaml
+++ b/vsts/cleanup-leftover-resources.yaml
@@ -1,0 +1,28 @@
+name: $(BuildID)_cleanup_leftover_resources
+
+# This is a scheduled maintenance pipeline only. It must never run on code pushes or PRs.
+trigger: none
+pr: none
+
+# Run every 4 hours. 'always: true' makes the schedule fire even when there are no new commits.
+schedules:
+- cron: '0 */4 * * *'
+  displayName: Every 4 hours
+  branches:
+    include:
+    - master
+  always: true
+
+variables:
+  Horton.FrameworkRoot: $(Build.SourcesDirectory)
+
+stages:
+- stage: cleanup
+  jobs:
+  - job: cleanup_leftover_resources
+    pool:
+      vmImage: 'ubuntu-24.04'
+    steps:
+    - template: templates/steps-cleanup-leftover-resources.yaml
+      parameters:
+        minimumAgeHours: 3

--- a/vsts/templates/steps-cleanup-leftover-resources.yaml
+++ b/vsts/templates/steps-cleanup-leftover-resources.yaml
@@ -2,6 +2,16 @@ parameters:
   # Resource groups created this many hours ago or less are left untouched so that
   # in-progress pipeline runs are never disturbed.
   minimumAgeHours: 3
+  # Resource group name prefix to match. Leave empty to use this framework's own prefix
+  # (Get-AzureResourceGroupNamePrefix). Another repository reusing this template should pass
+  # the prefix its own pipelines use, so that only its resource groups are deleted.
+  resourceGroupPrefix: ''
+  # Azure Resource Manager service connection used to authenticate the cleanup.
+  azureSubscription: 'iot hub sdk service connection'
+  # Path to a checkout of the iot-sdks-e2e-fx framework, which provides the cleanup module.
+  # Defaults to the current repository; a reusing repository that checks the framework out
+  # elsewhere should point this at that location.
+  frameworkRoot: '$(Build.SourcesDirectory)'
 
 steps:
 - checkout: self
@@ -9,14 +19,20 @@ steps:
 - task: AzureCLI@2
   displayName: Clean up leftover Azure resource groups
   inputs:
-    azureSubscription: 'iot hub sdk service connection'
+    azureSubscription: '${{ parameters.azureSubscription }}'
     scriptType: 'pscore'
     scriptLocation: 'inlineScript'
     inlineScript: |
       $ErrorActionPreference = 'Stop'
 
-      # The module is the single source of truth for both the resource-group name prefix and
-      # the cleanup logic, so it deletes exactly (and only) what the pipelines create.
-      Import-Module "$env:BUILD_SOURCESDIRECTORY/scripts/Azure.Iot.Sdk.Test.psm1" -Force
+      # The module is the single source of truth for the cleanup logic, so it deletes exactly
+      # (and only) the resource groups whose names start with the configured prefix.
+      Import-Module "${{ parameters.frameworkRoot }}/scripts/Azure.Iot.Sdk.Test.psm1" -Force
 
-      Remove-LeftoverAzureResourceGroups -MinimumAgeHours ${{ parameters.minimumAgeHours }}
+      $prefix = '${{ parameters.resourceGroupPrefix }}'
+      if ([string]::IsNullOrWhiteSpace($prefix)) {
+          # No prefix supplied: fall back to this framework's own prefix.
+          Remove-LeftoverAzureResourceGroups -MinimumAgeHours ${{ parameters.minimumAgeHours }}
+      } else {
+          Remove-LeftoverAzureResourceGroups -Prefix $prefix -MinimumAgeHours ${{ parameters.minimumAgeHours }}
+      }

--- a/vsts/templates/steps-cleanup-leftover-resources.yaml
+++ b/vsts/templates/steps-cleanup-leftover-resources.yaml
@@ -1,0 +1,22 @@
+parameters:
+  # Resource groups created this many hours ago or less are left untouched so that
+  # in-progress pipeline runs are never disturbed.
+  minimumAgeHours: 3
+
+steps:
+- checkout: self
+
+- task: AzureCLI@2
+  displayName: Clean up leftover Azure resource groups
+  inputs:
+    azureSubscription: 'iot hub sdk service connection'
+    scriptType: 'pscore'
+    scriptLocation: 'inlineScript'
+    inlineScript: |
+      $ErrorActionPreference = 'Stop'
+
+      # The module is the single source of truth for both the resource-group name prefix and
+      # the cleanup logic, so it deletes exactly (and only) what the pipelines create.
+      Import-Module "$env:BUILD_SOURCESDIRECTORY/scripts/Azure.Iot.Sdk.Test.psm1" -Force
+
+      Remove-LeftoverAzureResourceGroups -MinimumAgeHours ${{ parameters.minimumAgeHours }}


### PR DESCRIPTION
## Why

When a pipeline run is **canceled**, Azure DevOps does not start the per-run `cleanup` stage. `condition: always()` forces a step/stage to run when a dependency **fails**, but it does **not** start a not-yet-started stage when the run is **canceled** — the scheduler simply stops. The resource group provisioned in the `setup` stage is then left behind in the subscription. (Concrete example: the canceled PR run `159849` left `rg-…` behind with its `CreatedOn`/`AzDevOpsRunUrl` tags intact.)

## What

- **Unique RG prefix** — `Get-AzureResourceGroupNamePrefix` is the single source of truth for the resource-group name prefix, now `rg-iot-sdk-e2e-` (was the generic `rg-`, which could collide with unrelated groups). `New-AzureResourceGroupName` uses it as the default and now caps the final name at Azure's **90-character** limit.
- **Cleanup function** — `Remove-LeftoverAzureResourceGroups -MinimumAgeHours <n>` deletes resource groups whose name matches that prefix and whose `CreatedOn` tag indicates an age greater than the threshold (default **3 hours**), so in-progress runs are never disturbed. Groups with a missing/unparseable `CreatedOn` tag are skipped (age can't be determined safely). Supports `-WhatIf`.
- **Scheduled pipeline** — `vsts/cleanup-leftover-resources.yaml` runs **every 4 hours** (`cron: '0 */4 * * *'`, `always: true`, `trigger: none`/`pr: none`) and invokes the function via `vsts/templates/steps-cleanup-leftover-resources.yaml` (ubuntu-24.04, `AzureCLI@2`, imports the module so creation and cleanup share one prefix).

## Notes

- A new Azure DevOps pipeline must be created pointing at `vsts/cleanup-leftover-resources.yaml` on `master` for the cron schedule to take effect.
- Pre-existing resource groups created with the old `rg-<guid>` prefix are not matched and need a one-time manual sweep.

## Testing

- Module imports cleanly on PowerShell 7.
- Verified the 90-char cap, the new prefix, and the 3-hour boundary (2h/3h kept, 4h/10h deleted, missing-tag skipped, non-matching prefix ignored) with a mocked `az` (no real Azure calls, no deletions).
