### PR TITLE
Route node image npm installs through CFS-protected feed

### DIFF
--- a/bin/build/horton_build.py
+++ b/bin/build/horton_build.py
@@ -69,6 +69,11 @@ def build_image(tags):
     npm_registry = os.environ.get("NPM_REGISTRY")
     if npm_registry and tags.variant and tags.variant.startswith("node"):
         build_args["NPM_REGISTRY"] = npm_registry
+    if tags.variant and tags.variant.startswith("node"):
+        # Surface the npm registry in every pipeline run (docker layer caching can
+        # hide an equivalent `RUN echo` inside the image).
+        registry_in_use = npm_registry or "https://registry.npmjs.org/ (default)"
+        print(Fore.YELLOW + "npm registry for this build: " + registry_in_use)
 
     build_arg_string = ""
     for arg in build_args:

--- a/bin/build/horton_build.py
+++ b/bin/build/horton_build.py
@@ -63,6 +63,13 @@ def build_image(tags):
         "HORTON_COMMIT_NAME": tags.commit_name,
         "HORTON_COMMIT_SHA": tags.commit_sha,
     }
+    # Node images run `npm install` during `docker build`. On Microsoft-managed agents the
+    # public npm registries are blocked, so forward the CFS-protected feed (provided via the
+    # NPM_REGISTRY environment variable in the pipeline) into the build as a build-arg.
+    npm_registry = os.environ.get("NPM_REGISTRY")
+    if npm_registry and tags.variant and tags.variant.startswith("node"):
+        build_args["NPM_REGISTRY"] = npm_registry
+
     build_arg_string = ""
     for arg in build_args:
         build_arg_string += "--build-arg {}={} ".format(arg, build_args[arg])

--- a/docker_images/node/Dockerfile.node16
+++ b/docker_images/node/Dockerfile.node16
@@ -11,6 +11,14 @@ RUN apt update \
 RUN update-alternatives --install /usr/bin/python python $(which python3) 50 \
 &&  update-alternatives --install /usr/bin/pip pip $(which pip3) 50 
 
+# Direct access to public npm registries is blocked on Microsoft-managed build agents.
+# Default to the public registry so external/local `docker build` still works; CI overrides
+# this with --build-arg NPM_REGISTRY=<CFS feed> (see vsts/templates/steps-build-docker-image.yaml).
+# npm's default replace-registry-host=npmjs rewrites any registry.npmjs.org tarball URLs in
+# package-lock.json to the configured registry.
+ARG NPM_REGISTRY=https://registry.npmjs.org/
+ENV npm_config_registry=${NPM_REGISTRY}
+
 RUN npm install lerna@^6 -g
 
 RUN pip install --upgrade pip 

--- a/docker_images/node/Dockerfile.node18
+++ b/docker_images/node/Dockerfile.node18
@@ -11,6 +11,14 @@ RUN apt update \
 RUN update-alternatives --install /usr/bin/python python $(which python3) 50 \
 &&  update-alternatives --install /usr/bin/pip pip $(which pip3) 50 
 
+# Direct access to public npm registries is blocked on Microsoft-managed build agents.
+# Default to the public registry so external/local `docker build` still works; CI overrides
+# this with --build-arg NPM_REGISTRY=<CFS feed> (see vsts/templates/steps-build-docker-image.yaml).
+# npm's default replace-registry-host=npmjs rewrites any registry.npmjs.org tarball URLs in
+# package-lock.json to the configured registry.
+ARG NPM_REGISTRY=https://registry.npmjs.org/
+ENV npm_config_registry=${NPM_REGISTRY}
+
 RUN npm install lerna@^6 -g
 
 RUN pip install --break-system-packages --upgrade pip 

--- a/vsts/templates/steps-build-docker-image.yaml
+++ b/vsts/templates/steps-build-docker-image.yaml
@@ -239,6 +239,7 @@ steps:
     fi
     echo "Commit SHA: ${COMMIT_SHA}"
 
+    echo "npm registry for ${IMAGE_NAME}: ${NPM_REGISTRY:-https://registry.npmjs.org/ (default)}"
     echo "Building ${IMAGE_NAME}..."
     docker build \
       --tag "${IMAGE_NAME}" \

--- a/vsts/templates/steps-build-docker-image.yaml
+++ b/vsts/templates/steps-build-docker-image.yaml
@@ -199,6 +199,9 @@ steps:
     IOTHUB_E2E_REPO_ADDRESS: $(IOTHUB-E2E-REPO-ADDRESS)
     IOTHUB_E2E_REPO_USER: $(IOTHUB-E2E-REPO-USER)
     IOTHUB_E2E_REPO_PASSWORD: $(IOTHUB-E2E-REPO-PASSWORD)
+    # Public npm registries are blocked on Microsoft-managed agents; node docker builds
+    # pull packages through the CFS-protected feed (forwarded into the build by horton_build.py).
+    NPM_REGISTRY: https://packagefeedproxy.microsoft.io/npm/
   condition: and(succeeded(), eq(variables['buildImage'],'yes'))
 
 - bash: |
@@ -243,6 +246,7 @@ steps:
       --build-arg HORTON_REPO="${NODE_REPO}" \
       --build-arg HORTON_COMMIT_NAME="${NODE_BRANCH}" \
       --build-arg HORTON_COMMIT_SHA="${COMMIT_SHA}" \
+      --build-arg NPM_REGISTRY="${NPM_REGISTRY:-https://registry.npmjs.org/}" \
       "${CONTEXT}"
 
     echo "Pushing ${IMAGE_NAME}..."
@@ -251,5 +255,8 @@ steps:
   displayName: "build and push default-friend-module"
   env:
     IOTHUB_E2E_REPO_ADDRESS: $(IOTHUB-E2E-REPO-ADDRESS)
+    # Public npm registries are blocked on Microsoft-managed agents; build the node image
+    # against the CFS-protected feed.
+    NPM_REGISTRY: https://packagefeedproxy.microsoft.io/npm/
   condition: and(succeeded(), eq(variables['buildImage'],'yes'))
 


### PR DESCRIPTION
## Why

Following the CISO/MSProtect rollout, **direct access to public npm registries** (`registry.npmjs.org`, `registry.yarnpkg.com`, `registry.npmmirror.com`) is being **blocked on Microsoft-managed devices and build agents**. This is the companion change to [Azure/azure-iot-sdk-node#1256](https://github.com/Azure/azure-iot-sdk-node/pull/1256).

## The key difference from the azure-iot-sdk-node fix

In `azure-iot-sdk-node`, `npm install` runs as a normal pipeline step, so setting an `npm_config_registry` pipeline variable was enough. **Here it is not**: the node e2e wrapper images run every `npm install` **inside `docker build`**:

- `RUN npm install lerna@^6 -g` (in `Dockerfile.node16` / `Dockerfile.node18`)
- `prebuild.sh` → `npm install`
- `rebuild.sh` → `lerna bootstrap --hoist` (which runs `npm install` per package)

A pipeline environment variable on the agent does **not** propagate into a `docker build`, so the registry has to be threaded in as a build-arg.

## What changed

1. **`docker_images/node/Dockerfile.node16` + `Dockerfile.node18`** — add
   ```dockerfile
   ARG NPM_REGISTRY=https://registry.npmjs.org/
   ENV npm_config_registry=${NPM_REGISTRY}
   ```
   before the first npm command. The default is the **public** registry, so external/local `docker build` (and off-corpnet builds) are unchanged. `ENV npm_config_registry` covers every npm/npx/lerna invocation in the build and at container runtime.

2. **`bin/build/horton_build.py`** — the `horton build` CLI now forwards `NPM_REGISTRY` as a `--build-arg` for **node** variants when the env var is set (no-op for c/csharp/java/python and when unset).

3. **`vsts/templates/steps-build-docker-image.yaml`** — supplies the CFS-protected feed (`https://packagefeedproxy.microsoft.io/npm/`) via the `NPM_REGISTRY` env var on the horton build step, and adds a matching `--build-arg` to the explicit `default-friend-module` docker build.

Because these live in the shared template, the fix applies both to this repo's `gate-node` and to the `horton-node-gate` triggered from `azure-iot-sdk-node` — no change is required in consuming repos.

## Design note

The internal CFS feed URL appears **only in the pipeline template**, matching the approach already merged in azure-iot-sdk-node. The in-source Dockerfile default stays on the public registry, overridable with `--build-arg NPM_REGISTRY=...`. npm's default `replace-registry-host=npmjs` rewrites the `registry.npmjs.org` tarball URLs in any `package-lock.json` to the configured registry, so no lockfiles change.

## Scope

Only the node images use npm; the c/csharp/java/python images are unaffected. `node16` is patched for parity even though the active gate matrix builds only `node18`.
