### PR TITLE
Stop discarding Azure CLI stderr during provisioning

### DIFF
--- a/scripts/Azure.Iot.Sdk.Test.psm1
+++ b/scripts/Azure.Iot.Sdk.Test.psm1
@@ -1541,7 +1541,7 @@ function New-AzIotTestEnvironment {
         Stop-OnError -Step "Get Azure account information"
         $AzureSubscriptionId = $AzureAccount.id
     } else {
-        $discard = az account set --subscription "$AzureSubscriptionId" --only-show-errors 2>$null
+        $discard = az account set --subscription "$AzureSubscriptionId" --only-show-errors
         Stop-OnError -Step "Set Azure subscription"
     }
 
@@ -1604,7 +1604,7 @@ function New-AzIotTestEnvironment {
 
         Write-Host "Creating Azure resource group ($ResourceGroup; $ResourceGroupTagsString)"
 
-        $AzureResourceGroup = az group create --name "$ResourceGroup" --location "$AzureLocation" 2>$null | ConvertFrom-json 
+        $AzureResourceGroup = az group create --name "$ResourceGroup" --location "$AzureLocation" | ConvertFrom-json 
 
         Stop-OnError -Step "Create Azure resource group"
 
@@ -1634,13 +1634,13 @@ function New-AzIotTestEnvironment {
 
         $CertMgmtUserIdentity = "$($ResourceGroup)cmuid"
         Write-Host "Creating User-Assigned Managed Identity (UAMI) ($CertMgmtUserIdentity)"
-        $AzureCertMgmtIdentity = az identity create --name "$CertMgmtUserIdentity" --resource-group "$ResourceGroup" --location "$AzureLocation" 2>$null | ConvertFrom-Json
+        $AzureCertMgmtIdentity = az identity create --name "$CertMgmtUserIdentity" --resource-group "$ResourceGroup" --location "$AzureLocation" | ConvertFrom-Json
         Stop-OnError -Step "Create User-Assigned Managed Identity (UAMI)"
 
         $AzureAdrNamespaceName = "azure-adr-ns"
         $AzureAdrPolicyName = "azure-adr-policy"
         Write-Host "Creating ADR Namespace (ns=$AzureAdrNamespaceName; policy=$AzureAdrPolicyName)"
-        $AzureAdrNamespace = az iot adr ns create --name "$AzureAdrNamespaceName" --enable-certificate-management --resource-group "$ResourceGroup" --location "$AzureLocation" --policy-name "$AzureAdrPolicyName" 2>$null | ConvertFrom-Json
+        $AzureAdrNamespace = az iot adr ns create --name "$AzureAdrNamespaceName" --enable-certificate-management --resource-group "$ResourceGroup" --location "$AzureLocation" --policy-name "$AzureAdrPolicyName" | ConvertFrom-Json
         Stop-OnError -Step "Create ADR Namespace"    
 
         Write-Host "Assigning ADR custom role to UAMI (a5c3590a-3a1a-4cd4-9648-ea0a32b15137)"
@@ -1931,7 +1931,7 @@ function Get-AzIotTestEnvironment {
         Stop-OnError -Step "Get Azure account information"
         $AzureSubscriptionId = $AzureAccount.id
     } else {
-        $discard = az account set --subscription "$AzureSubscriptionId" --only-show-errors 2>$null
+        $discard = az account set --subscription "$AzureSubscriptionId" --only-show-errors
         Stop-OnError -Step "Set Azure subscription"
     }
 


### PR DESCRIPTION
## Problem

Provisioning call sites in `scripts/Azure.Iot.Sdk.Test.psm1` are written as:

```powershell
$AzureAdrNamespace = az iot adr ns create ... 2>$null | ConvertFrom-Json
Stop-OnError -Step "Create ADR Namespace"
```

`2>$null` throws away everything Azure CLI wrote to stderr — including the error. So when `az iot adr ns create` started failing on 2026-07-28, every consuming CI run showed nothing but:

```
ERROR: "Create ADR Namespace" failed (exit code 1)
```

The actual cause (a `400 ResourceCreationValidateFailed` from `Microsoft.DeviceRegistry`) had to be recovered out-of-band from the Azure activity log — see Azure/azure-iot-sdk#37. That is a diagnosability bug worth fixing on its own: this module is downloaded at runtime by GitHub Actions in several SDK repos, so a swallowed error costs everyone a manual Azure investigation.

## Change

Delete the `2>$null` from the call sites that discard stderr and then hard-fail on the exit code:

- `az account set` (both `New-AzIotTestEnvironment` and `Get-AzIotTestEnvironment`)
- `az group create`
- `az identity create`
- `az iot adr ns create`

Unredirected stderr goes straight to the CI log, stdout still feeds `ConvertFrom-Json`, and `$LASTEXITCODE` still reaches `Stop-OnError`. This is already how the rest of the module invokes `az` (`az iot dps enrollment create`, `az group show`, `az account show`, `az extension list`, ...) — these five lines were the outliers.

stderr is deliberately *not* merged with `2>&1`: that would concatenate CLI preview/extension notices with the JSON payload on the success path.

The `az account show` login probes keep `2>$null` — there a failure is expected and already handled by falling through to `az login`.

## Validation

Failure path — the CLI's own error now reaches the log, `ConvertFrom-Json` on empty stdout is a no-op, and the exit code still survives the pipeline for `Stop-OnError` (run with `$ErrorActionPreference = "Stop"`, matching the `azure/powershell` action's wrapper, to confirm unredirected native stderr does not trip `NativeCommandError`):

```
ERROR: (ResourceGroupNotFound) Resource group 'no-such-rg-ewertons-zzz' could not be found.
Code: ResourceGroupNotFound
Message: Resource group 'no-such-rg-ewertons-zzz' could not be found.
REACHED-STOPONERROR LASTEXITCODE=3 xIsNull=True
```

Before this change only the swallowed exit code remained.

Success path — JSON still parses cleanly:

```
PARSED-OK count=8 LASTEXITCODE=0
```
