### PR TITLE
Tolerate ADR RBAC propagation when creating IoT Hub/DPS with certificate management

### DIFF
--- a/scripts/Azure.Iot.Sdk.Test.psm1
+++ b/scripts/Azure.Iot.Sdk.Test.psm1
@@ -114,13 +114,17 @@ function Stop-OnError {
     }
 }
 
-function Invoke-AzCliWithRetry {
+function Invoke-WithRetry {
     <#
     .SYNOPSIS
-    Runs an `az` command, retrying with backoff while its stderr matches a
-    pattern known to be transient. Returns stdout parsed from JSON.
+    Runs a script block, retrying with backoff while its stderr matches a
+    pattern known to be transient.
 
     .DESCRIPTION
+    Takes the command as a script block so call sites keep ordinary `az` syntax
+    -- named arguments, line continuations, and `| ConvertFrom-Json` all stay
+    exactly where they were. Whatever the block returns is returned unchanged.
+
     The motivating case is Azure RBAC propagation. `az role assignment create`
     returns as soon as the assignment reaches the RBAC store, but the resource
     providers that ENFORCE it cache permissions and can take minutes to observe
@@ -131,15 +135,18 @@ function Invoke-AzCliWithRetry {
     errors (bad name, quota exhausted, invalid SKU) into slow failures instead
     of fast ones.
 
-    stderr is captured to a temp file rather than merged with `2>&1` so that CLI
-    warnings (preview/extension notices) can never end up concatenated with the
-    JSON payload on the success path.
+    stderr is redirected to a temp file rather than merged with `2>&1`, for two
+    reasons: merged native stderr raises NativeCommandError under
+    `$ErrorActionPreference = 'Stop'` (which the azure/powershell task sets),
+    and merging would concatenate CLI preview/extension notices into the JSON
+    the block is piping to ConvertFrom-Json.
 
     .PARAMETER Step
     Human-readable step name, used in the error message.
 
-    .PARAMETER Arguments
-    Arguments passed through to `az`.
+    .PARAMETER Command
+    Script block to run. Runs in its defining scope, so it can use the caller's
+    variables normally.
 
     .PARAMETER RetryOnPattern
     Regex matched against stderr. Only matching failures are retried.
@@ -151,11 +158,13 @@ function Invoke-AzCliWithRetry {
     Delay before the second attempt; doubles thereafter.
 
     .EXAMPLE
-    PS> $hub = Invoke-AzCliWithRetry -Step "Create hub" -RetryOnPattern '400913' -Arguments @("iot", "hub", "create", "--name", $Name)
+    PS> $Hub = Invoke-WithRetry -Step "Create Azure IoT Hub" -RetryOnPattern '400913' -Command {
+    PS>     az iot hub create --name "$IotHubName" --resource-group "$ResourceGroup" | ConvertFrom-Json
+    PS> }
     #>
     param(
         [Parameter(Mandatory = $true)][string]$Step,
-        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [Parameter(Mandatory = $true)][scriptblock]$Command,
         [Parameter(Mandatory = $true)][string]$RetryOnPattern,
         [int]$MaxAttempts = 4,
         [int]$InitialDelaySeconds = 30
@@ -166,8 +175,19 @@ function Invoke-AzCliWithRetry {
     for ($Attempt = 1; $Attempt -le $MaxAttempts; $Attempt++) {
         $StdErrFile = New-TempFile
         try {
-            $StdOut = & az @Arguments 2>$StdErrFile
-            $AzExitCode = $LASTEXITCODE
+            $Result = $null
+            $Caught = $null
+            $global:LASTEXITCODE = 0
+
+            try {
+                $Result = & $Command 2>$StdErrFile
+            } catch {
+                # e.g. ConvertFrom-Json choking on the empty stdout of a failed
+                # command. The real diagnosis is the exit code plus stderr below.
+                $Caught = $_
+            }
+
+            $ExitCode = $LASTEXITCODE
 
             $StdErr = $null
             if (Test-Path -Path $StdErrFile) {
@@ -177,24 +197,24 @@ function Invoke-AzCliWithRetry {
             if (-not [string]::IsNullOrWhiteSpace($StdErr)) {
                 # Printed on success too: az writes preview/extension notices to
                 # stderr, and those are worth having in the log.
-                Write-Host "az output for `"$Step`" (attempt $Attempt of $MaxAttempts):"
+                Write-Host "Output for `"$Step`" (attempt $Attempt of $MaxAttempts):"
                 Write-Host $StdErr.Trim()
             }
 
-            if ($AzExitCode -eq 0) {
-                if ([string]::IsNullOrWhiteSpace($StdOut)) {
-                    return $null
-                }
-                return ($StdOut | ConvertFrom-Json)
+            if ($ExitCode -eq 0 -and $null -eq $Caught) {
+                return $Result
             }
 
             $IsLastAttempt = ($Attempt -ge $MaxAttempts)
             $IsRetryable = ($null -ne $StdErr) -and ($StdErr -match $RetryOnPattern)
 
             if ($IsLastAttempt -or -not $IsRetryable) {
-                # Hand the CLI's own exit code to Stop-OnError so the failure is
-                # reported exactly like a non-retrying call site.
-                $global:LASTEXITCODE = $AzExitCode
+                if ($null -ne $Caught) {
+                    Write-Host $Caught.ToString()
+                }
+                # Hand the command's own exit code to Stop-OnError so the failure
+                # is reported exactly like a non-retrying call site.
+                $global:LASTEXITCODE = if ($ExitCode -ne 0) { $ExitCode } else { 1 }
                 Stop-OnError -Step $Step
                 return $null
             }
@@ -221,7 +241,7 @@ function Wait-AzRoleAssignment {
 
     This is NOT sufficient on its own -- providers cache permissions
     independently -- so callers must still tolerate an access-denied answer
-    afterwards (see Invoke-AzCliWithRetry). Doing both keeps the common case
+    afterwards (see Invoke-WithRetry). Doing both keeps the common case
     fast while still converging in the slow case.
 
     Never fails provisioning: on timeout it warns and returns, because the
@@ -1833,13 +1853,11 @@ function New-AzIotTestEnvironment {
         $AdrPermissionPropagationPattern = '400913|does not have the required DeviceRegistry permissions'
 
         Write-Host "Creating Azure IoT Hub ($IotHubName, with certificate management support)"
-        $AzureIoTHub = Invoke-AzCliWithRetry -Step "Create Azure IoT Hub (with certificate management support)" `
-            -RetryOnPattern $AdrPermissionPropagationPattern -Arguments @(
-                "iot", "hub", "create", "--name", "$IotHubName", "--resource-group", "$ResourceGroup",
-                "--location", "$AzureLocation", "--sku", "GEN2",
-                "--mi-user-assigned", "$($AzureCertMgmtIdentity.id)",
-                "--ns-resource-id", "$($AzureAdrNamespace.id)",
-                "--ns-identity-id", "$($AzureCertMgmtIdentity.id)")
+        $AzureIoTHub = Invoke-WithRetry -Step "Create Azure IoT Hub (with certificate management support)" `
+            -RetryOnPattern $AdrPermissionPropagationPattern -Command {
+            az iot hub create --name "$IotHubName" --resource-group "$ResourceGroup" --location "$AzureLocation" --sku GEN2 `
+                --mi-user-assigned "$($AzureCertMgmtIdentity.id)" --ns-resource-id "$($AzureAdrNamespace.id)" --ns-identity-id "$($AzureCertMgmtIdentity.id)" | ConvertFrom-Json
+        }
 
         Write-Host "Assigning Contributor role on Azure IoT for ADR principal"
         az role assignment create --assignee "$($AzureAdrNamespace.identity.principalId)" --role "Contributor" --scope "$($AzureIoTHub.id)" --only-show-errors | Out-Null
@@ -1851,14 +1869,11 @@ function New-AzIotTestEnvironment {
         
         if ($NoDps -eq $false) {
             Write-Host "Creating Device Provisioning Service with ADR integration ($DpsName)"
-            $AzureDps = Invoke-AzCliWithRetry -Step "Create Device Provisioning Service with ADR integration" `
-                -RetryOnPattern $AdrPermissionPropagationPattern -Arguments @(
-                    "iot", "dps", "create", "--name", "$DpsName", "--resource-group", "$ResourceGroup",
-                    "--location", "$AzureLocation",
-                    "--mi-user-assigned", "$($AzureCertMgmtIdentity.id)",
-                    "--ns-resource-id", "$($AzureAdrNamespace.id)",
-                    "--ns-identity-id", "$($AzureCertMgmtIdentity.id)",
-                    "--only-show-errors")
+            $AzureDps = Invoke-WithRetry -Step "Create Device Provisioning Service with ADR integration" `
+                -RetryOnPattern $AdrPermissionPropagationPattern -Command {
+                az iot dps create --name "$DpsName" --resource-group "$ResourceGroup" --location "$AzureLocation" `
+                    --mi-user-assigned "$($AzureCertMgmtIdentity.id)" --ns-resource-id "$($AzureAdrNamespace.id)" --ns-identity-id "$($AzureCertMgmtIdentity.id)" --only-show-errors | ConvertFrom-Json
+            }
         }
     } else {
         Write-Host "Creating Azure IoT Hub ($IotHubName)."

--- a/scripts/Azure.Iot.Sdk.Test.psm1
+++ b/scripts/Azure.Iot.Sdk.Test.psm1
@@ -114,6 +114,166 @@ function Stop-OnError {
     }
 }
 
+function Invoke-AzCliWithRetry {
+    <#
+    .SYNOPSIS
+    Runs an `az` command, retrying with backoff while its stderr matches a
+    pattern known to be transient. Returns stdout parsed from JSON.
+
+    .DESCRIPTION
+    The motivating case is Azure RBAC propagation. `az role assignment create`
+    returns as soon as the assignment reaches the RBAC store, but the resource
+    providers that ENFORCE it cache permissions and can take minutes to observe
+    the change. Handing a freshly-granted identity to another provider therefore
+    fails with an access-denied error that would have succeeded moments later.
+
+    -RetryOnPattern keeps that narrow: retrying every failure would turn genuine
+    errors (bad name, quota exhausted, invalid SKU) into slow failures instead
+    of fast ones.
+
+    stderr is captured to a temp file rather than merged with `2>&1` so that CLI
+    warnings (preview/extension notices) can never end up concatenated with the
+    JSON payload on the success path.
+
+    .PARAMETER Step
+    Human-readable step name, used in the error message.
+
+    .PARAMETER Arguments
+    Arguments passed through to `az`.
+
+    .PARAMETER RetryOnPattern
+    Regex matched against stderr. Only matching failures are retried.
+
+    .PARAMETER MaxAttempts
+    Total attempts, including the first.
+
+    .PARAMETER InitialDelaySeconds
+    Delay before the second attempt; doubles thereafter.
+
+    .EXAMPLE
+    PS> $hub = Invoke-AzCliWithRetry -Step "Create hub" -RetryOnPattern '400913' -Arguments @("iot", "hub", "create", "--name", $Name)
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Step,
+        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [Parameter(Mandatory = $true)][string]$RetryOnPattern,
+        [int]$MaxAttempts = 4,
+        [int]$InitialDelaySeconds = 30
+    )
+
+    $Delay = $InitialDelaySeconds
+
+    for ($Attempt = 1; $Attempt -le $MaxAttempts; $Attempt++) {
+        $StdErrFile = New-TempFile
+        try {
+            $StdOut = & az @Arguments 2>$StdErrFile
+            $AzExitCode = $LASTEXITCODE
+
+            $StdErr = $null
+            if (Test-Path -Path $StdErrFile) {
+                $StdErr = Get-Content -Path $StdErrFile -Raw
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($StdErr)) {
+                # Printed on success too: az writes preview/extension notices to
+                # stderr, and those are worth having in the log.
+                Write-Host "az output for `"$Step`" (attempt $Attempt of $MaxAttempts):"
+                Write-Host $StdErr.Trim()
+            }
+
+            if ($AzExitCode -eq 0) {
+                if ([string]::IsNullOrWhiteSpace($StdOut)) {
+                    return $null
+                }
+                return ($StdOut | ConvertFrom-Json)
+            }
+
+            $IsLastAttempt = ($Attempt -ge $MaxAttempts)
+            $IsRetryable = ($null -ne $StdErr) -and ($StdErr -match $RetryOnPattern)
+
+            if ($IsLastAttempt -or -not $IsRetryable) {
+                # Hand the CLI's own exit code to Stop-OnError so the failure is
+                # reported exactly like a non-retrying call site.
+                $global:LASTEXITCODE = $AzExitCode
+                Stop-OnError -Step $Step
+                return $null
+            }
+
+            Write-Host "`"$Step`" hit a transient error; retrying in $Delay seconds."
+            Start-Sleep -Seconds $Delay
+            $Delay = $Delay * 2
+        }
+        finally {
+            Remove-Item -Path $StdErrFile -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Wait-AzRoleAssignment {
+    <#
+    .SYNOPSIS
+    Blocks until the given role assignments can be read back at their scope.
+
+    .DESCRIPTION
+    `az role assignment create` exiting 0 only means the assignment reached the
+    RBAC store. Reading it back confirms that much, which is the earliest point
+    at which propagation to enforcing resource providers can even begin.
+
+    This is NOT sufficient on its own -- providers cache permissions
+    independently -- so callers must still tolerate an access-denied answer
+    afterwards (see Invoke-AzCliWithRetry). Doing both keeps the common case
+    fast while still converging in the slow case.
+
+    Never fails provisioning: on timeout it warns and returns, because the
+    operation that actually matters is retried by its caller.
+
+    .PARAMETER PrincipalId
+    Object id of the principal the roles were granted to.
+
+    .PARAMETER Scope
+    Resource id the assignments were created against.
+
+    .PARAMETER RoleDefinitionIds
+    Role definition GUIDs expected to be present.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$PrincipalId,
+        [Parameter(Mandatory = $true)][string]$Scope,
+        [Parameter(Mandatory = $true)][string[]]$RoleDefinitionIds,
+        [int]$TimeoutSeconds = 120,
+        [int]$PollIntervalSeconds = 10
+    )
+
+    $Deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+
+    while ($true) {
+        $Assignments = az role assignment list --assignee "$PrincipalId" --scope "$Scope" --only-show-errors | ConvertFrom-Json
+
+        $Observed = @()
+        if ($null -ne $Assignments) {
+            $Observed = @($Assignments | ForEach-Object { $_.roleDefinitionId })
+        }
+
+        $Missing = @($RoleDefinitionIds | Where-Object {
+            $RoleId = $_
+            -not ($Observed | Where-Object { $_ -like "*$RoleId" })
+        })
+
+        if ($Missing.Count -eq 0) {
+            Write-Host "All $($RoleDefinitionIds.Count) role assignment(s) are visible at $Scope."
+            return
+        }
+
+        if ((Get-Date) -ge $Deadline) {
+            Write-Host "WARNING: $($Missing.Count) role assignment(s) still not visible after $TimeoutSeconds seconds: $($Missing -join ', '). Continuing; the dependent step retries on access-denied."
+            return
+        }
+
+        Write-Host "Waiting for $($Missing.Count) role assignment(s) to become visible; polling again in $PollIntervalSeconds seconds."
+        Start-Sleep -Seconds $PollIntervalSeconds
+    }
+}
+
 function Set-ResourceGroupTags {
     param(
         [string]$ResourceGroupId,
@@ -1643,18 +1803,43 @@ function New-AzIotTestEnvironment {
         $AzureAdrNamespace = az iot adr ns create --name "$AzureAdrNamespaceName" --enable-certificate-management --resource-group "$ResourceGroup" --location "$AzureLocation" --policy-name "$AzureAdrPolicyName" | ConvertFrom-Json
         Stop-OnError -Step "Create ADR Namespace"    
 
-        Write-Host "Assigning ADR custom role to UAMI (a5c3590a-3a1a-4cd4-9648-ea0a32b15137)"
-        az role assignment create --assignee "$($AzureCertMgmtIdentity.principalId)" --role "a5c3590a-3a1a-4cd4-9648-ea0a32b15137" --scope "$($AzureAdrNamespace.id)" --only-show-errors | Out-Null
+        # Azure Device Registry Contributor: namespaces/read,
+        # namespaces/devices/*, namespaces/credentials/policies/read.
+        $AdrContributorRoleId = "a5c3590a-3a1a-4cd4-9648-ea0a32b15137"
+        # Azure Device Registry Onboarding: namespaces/write,
+        # namespaces/credentials/*.
+        $AdrOnboardingRoleId = "547f7f0a-69c0-4807-bd9e-0321dfb66a84"
+
+        Write-Host "Assigning ADR custom role to UAMI ($AdrContributorRoleId)"
+        az role assignment create --assignee "$($AzureCertMgmtIdentity.principalId)" --role "$AdrContributorRoleId" --scope "$($AzureAdrNamespace.id)" --only-show-errors | Out-Null
         Stop-OnError -Step "Assign ADR custom role 1 to UAMI"
 
-        Write-Host "Assigning ADR custom role to UAMI (547f7f0a-69c0-4807-bd9e-0321dfb66a84)"
-        az role assignment create --assignee "$($AzureCertMgmtIdentity.principalId)" --role "547f7f0a-69c0-4807-bd9e-0321dfb66a84" --scope "$($AzureAdrNamespace.id)" --only-show-errors | Out-Null
+        Write-Host "Assigning ADR custom role to UAMI ($AdrOnboardingRoleId)"
+        az role assignment create --assignee "$($AzureCertMgmtIdentity.principalId)" --role "$AdrOnboardingRoleId" --scope "$($AzureAdrNamespace.id)" --only-show-errors | Out-Null
         Stop-OnError -Step "Assign ADR custom role 2 to UAMI"
 
+        # IoT Hub and DPS validate this UAMI's DeviceRegistry permissions while
+        # they are being created. The role assignments above were made seconds
+        # ago and the enforcing providers may not observe them yet, so wait for
+        # the assignments to be readable and then tolerate an access-denied
+        # answer for a few attempts. Without this the create fails with
+        # IH400913 "does not have the required DeviceRegistry permissions",
+        # which is purely a propagation artifact.
+        Wait-AzRoleAssignment `
+            -PrincipalId "$($AzureCertMgmtIdentity.principalId)" `
+            -Scope "$($AzureAdrNamespace.id)" `
+            -RoleDefinitionIds @($AdrContributorRoleId, $AdrOnboardingRoleId)
+
+        $AdrPermissionPropagationPattern = '400913|does not have the required DeviceRegistry permissions'
+
         Write-Host "Creating Azure IoT Hub ($IotHubName, with certificate management support)"
-        $AzureIoTHub = az iot hub create --name "$IotHubName" --resource-group "$ResourceGroup" --location "$AzureLocation" --sku GEN2 `
-            --mi-user-assigned "$($AzureCertMgmtIdentity.id)" --ns-resource-id "$($AzureAdrNamespace.id)" --ns-identity-id "$($AzureCertMgmtIdentity.id)" | ConvertFrom-Json
-        Stop-OnError -Step "Create Azure IoT Hub (with certificate management support)"
+        $AzureIoTHub = Invoke-AzCliWithRetry -Step "Create Azure IoT Hub (with certificate management support)" `
+            -RetryOnPattern $AdrPermissionPropagationPattern -Arguments @(
+                "iot", "hub", "create", "--name", "$IotHubName", "--resource-group", "$ResourceGroup",
+                "--location", "$AzureLocation", "--sku", "GEN2",
+                "--mi-user-assigned", "$($AzureCertMgmtIdentity.id)",
+                "--ns-resource-id", "$($AzureAdrNamespace.id)",
+                "--ns-identity-id", "$($AzureCertMgmtIdentity.id)")
 
         Write-Host "Assigning Contributor role on Azure IoT for ADR principal"
         az role assignment create --assignee "$($AzureAdrNamespace.identity.principalId)" --role "Contributor" --scope "$($AzureIoTHub.id)" --only-show-errors | Out-Null
@@ -1666,9 +1851,14 @@ function New-AzIotTestEnvironment {
         
         if ($NoDps -eq $false) {
             Write-Host "Creating Device Provisioning Service with ADR integration ($DpsName)"
-            $AzureDps = az iot dps create --name "$DpsName" --resource-group "$ResourceGroup" --location "$AzureLocation" `
-                --mi-user-assigned "$($AzureCertMgmtIdentity.id)" --ns-resource-id "$($AzureAdrNamespace.id)" --ns-identity-id "$($AzureCertMgmtIdentity.id)" --only-show-errors | ConvertFrom-Json
-            Stop-OnError -Step "Create Device Provisioning Service with ADR integration"
+            $AzureDps = Invoke-AzCliWithRetry -Step "Create Device Provisioning Service with ADR integration" `
+                -RetryOnPattern $AdrPermissionPropagationPattern -Arguments @(
+                    "iot", "dps", "create", "--name", "$DpsName", "--resource-group", "$ResourceGroup",
+                    "--location", "$AzureLocation",
+                    "--mi-user-assigned", "$($AzureCertMgmtIdentity.id)",
+                    "--ns-resource-id", "$($AzureAdrNamespace.id)",
+                    "--ns-identity-id", "$($AzureCertMgmtIdentity.id)",
+                    "--only-show-errors")
         }
     } else {
         Write-Host "Creating Azure IoT Hub ($IotHubName)."

--- a/scripts/Azure.Iot.Sdk.Test.psm1
+++ b/scripts/Azure.Iot.Sdk.Test.psm1
@@ -265,9 +265,26 @@ function Wait-AzRoleAssignment {
     )
 
     $Deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $LastQueryError = $null
 
     while ($true) {
-        $Assignments = az role assignment list --assignee "$PrincipalId" --scope "$Scope" --only-show-errors | ConvertFrom-Json
+        # The query itself must never abort provisioning. `az` can fail (throttling,
+        # transient ARM error) and ConvertFrom-Json then throws on empty/non-JSON
+        # stdout -- which under $ErrorActionPreference = 'Stop' would propagate and
+        # kill the run. Treat any failure here as "not visible yet" and keep polling.
+        $Assignments = $null
+        $LastQueryError = $null
+        try {
+            $global:LASTEXITCODE = 0
+            $Assignments = az role assignment list --assignee "$PrincipalId" --scope "$Scope" --only-show-errors | ConvertFrom-Json
+            if ($LASTEXITCODE -ne 0) {
+                # az failed but wrote nothing to stdout, so ConvertFrom-Json had
+                # nothing to choke on and did not throw. Record it explicitly.
+                $LastQueryError = "az exited with code $LASTEXITCODE"
+            }
+        } catch {
+            $LastQueryError = $_.Exception.Message
+        }
 
         $Observed = @()
         if ($null -ne $Assignments) {
@@ -286,6 +303,11 @@ function Wait-AzRoleAssignment {
 
         if ((Get-Date) -ge $Deadline) {
             Write-Host "WARNING: $($Missing.Count) role assignment(s) still not visible after $TimeoutSeconds seconds: $($Missing -join ', '). Continuing; the dependent step retries on access-denied."
+            if ($null -ne $LastQueryError) {
+                # Surface it: repeated query failures mean the wait told us nothing,
+                # which is worth knowing when diagnosing a later access-denied error.
+                Write-Host "WARNING: the last role assignment query also failed: $($LastQueryError.Exception.Message)"
+            }
             return
         }
 

--- a/scripts/Azure.Iot.Sdk.Test.psm1
+++ b/scripts/Azure.Iot.Sdk.Test.psm1
@@ -306,7 +306,7 @@ function Wait-AzRoleAssignment {
             if ($null -ne $LastQueryError) {
                 # Surface it: repeated query failures mean the wait told us nothing,
                 # which is worth knowing when diagnosing a later access-denied error.
-                Write-Host "WARNING: the last role assignment query also failed: $($LastQueryError.Exception.Message)"
+                Write-Host "WARNING: the last role assignment query also failed: $LastQueryError"
             }
             return
         }


### PR DESCRIPTION
## Problem

`New-AzIotTestEnvironment -EnableCertificateManagement` fails intermittently —
and has been failing on essentially every run since 2026-08-02 — at:

```
ERROR: (400913) Access denied. The User Assigned Managed Identity
'.../CSDKE2ECert-<runid>-1cmuid' does not have the required DeviceRegistry
permissions [Microsoft.DeviceRegistry/namespaces/read,
Microsoft.DeviceRegistry/namespaces/devices/read,
Microsoft.DeviceRegistry/namespaces/devices/write,
Microsoft.DeviceRegistry/namespaces/credentials/policies/read]
on resource '.../azure-adr-ns' ... Please assign the 'DeviceRegistry
Contributor' or equivalent RBAC role to the managed identity.
ERROR: "Create Azure IoT Hub (with certificate management support)" failed (exit code 1)
```

This blocks `ci-c-e2e-csr` in `Azure/azure-iot-sdk` on **`main` and every branch**,
so it shows up as an unrelated red check on PRs that touch nothing.

## Root cause — not a missing role

The obvious reading is that a role assignment is missing. It is not. The script
already grants the UAMI both required roles, and resolving them confirms they
jointly cover every action the error lists:

| Role definition | Name | Relevant actions |
| --- | --- | --- |
| `a5c3590a-3a1a-4cd4-9648-ea0a32b15137` | Azure Device Registry Contributor | `namespaces/read`, `namespaces/devices/*`, `namespaces/credentials/policies/read` |
| `547f7f0a-69c0-4807-bd9e-0321dfb66a84` | Azure Device Registry Onboarding | `namespaces/read`, `namespaces/write`, `namespaces/credentials/*` |

The real cause is **RBAC propagation**. `az role assignment create` returns as
soon as the assignment reaches the RBAC store, but the resource providers that
*enforce* it cache permissions independently. The script granted the roles and
then immediately called `az iot hub create`, which validates the UAMI's
DeviceRegistry permissions server-side. When the IoT Hub RP had not yet observed
the grant, the create was rejected.

That also explains the intermittency: identical code succeeded on 8/1 and failed
on 8/2, and the same commit passes or fails depending on how quickly propagation
happens to complete.

## Fix

Two complementary changes, because neither is sufficient alone.

**`Wait-AzRoleAssignment`** polls until the assignments are readable back at
their scope. That confirms the write landed and is the earliest point at which
propagation can even begin. It never fails provisioning — on timeout it warns
and continues, because the operation that matters is retried anyway.

**`Invoke-AzCliWithRetry`** wraps the hub and DPS creation, retrying with
exponential backoff (30s, 60s, 120s; 4 attempts) *only* when stderr matches
`400913|does not have the required DeviceRegistry permissions`. Scoping the
retry to that pattern matters: retrying every failure would turn genuine errors
— bad name, quota exhausted, invalid SKU — into slow failures instead of fast
ones.

It follows the same conventions as the surrounding code: returns stdout parsed
from JSON, reports failures through `Stop-OnError` with the CLI's own exit code,
and captures stderr to a temp file rather than merging with `2>&1` so preview
and extension notices can never be concatenated into the JSON payload
(preserving the intent of #422).

The two role GUIDs are also now named constants with a comment identifying them,
since a bare GUID in an error message is what made this look like a
missing-permission problem in the first place.

## Verification

The failure only reproduces against live Azure under specific timing, so the
retry logic was tested against a stubbed `az` on `PATH` that emits the real
`(400913)` text a configurable number of times:

| Scenario | Expected | Result |
| --- | --- | --- |
| 2 transient failures then success | retries, returns parsed JSON, succeeds on attempt 3 | pass |
| First attempt succeeds | no retry, no delay | pass |
| Non-matching error (e.g. quota) | fails immediately, exit 1, no backoff | pass |
| All attempts fail | exits 1 via `Stop-OnError` after backoff | pass |
| `Wait-AzRoleAssignment`, both roles present | detects and returns | pass |
| `Wait-AzRoleAssignment`, one role missing | warns on timeout, names only the missing role | pass |

The module also parses clean (`[Parser]::ParseFile`, 0 errors), and the diff is
additive apart from the two rewired call sites.

## Notes for reviewers

- No behaviour change when `-EnableCertificateManagement` is not set.
- Worst case adds ~2 minutes before a genuine hard failure in the cert-management
  path; typical case adds only the role-visibility poll (a few seconds).
- `Invoke-AzCliWithRetry` requires `-RetryOnPattern` deliberately, so a future
  call site cannot accidentally opt into retrying everything.
