### PR TITLE
Name the e2e resource group from the build so cleanup can find it without an artifact

### DIFF
--- a/vsts/templates/steps-create-azure-resources.yaml
+++ b/vsts/templates/steps-create-azure-resources.yaml
@@ -1,5 +1,14 @@
 parameters:
   azure_location: 'centraluseuap'
+  # Resource group to provision into. The default is assembled from the build id, which is
+  # unique to this run and readable from every stage, so the cleanup stage can name the same
+  # group without the setup job having to hand the name over. A setup job that is cancelled
+  # or loses its agent therefore still gets cleaned up.
+  #
+  # Keep the prefix in step with Get-AzureResourceGroupNamePrefix in
+  # scripts/Azure.Iot.Sdk.Test.psm1: the scheduled cleanup pipeline finds leftover groups by
+  # that prefix, and would stop matching these groups if the two drift apart.
+  resourceGroupName: 'rg-iot-sdk-e2e-$(Build.BuildId)'
 
 steps:
 - checkout: none
@@ -14,7 +23,13 @@ steps:
     inlineScript: |
       Import-Module "$(Horton.FrameworkRoot)/scripts/Azure.Iot.Sdk.Test.psm1"
 
-      $ResourceGroupName = New-AzureResourceGroupName -OutFile "test_config/azure-resource-group-name.txt"
+      $ResourceGroupName = "${{ parameters.resourceGroupName }}"
+
+      # Recorded so a human reading the run can see which group it used. The cleanup stage
+      # derives the same name itself and does not depend on this file.
+      New-Item -ItemType Directory -Force -Path test_config | Out-Null
+      Set-Content -Path test_config/azure-resource-group-name.txt -Value $ResourceGroupName -NoNewline
+
       $TestEnvInfo = New-AzIotTestEnvironment -AzureLocation "${{ parameters.azure_location }}" -ResourceGroup $ResourceGroupName -NoDps -AddContainerRegistry -EnableFileUpload
       New-AzIotHortonTestConfig -TestEnvInfo $TestEnvInfo -Target bash -OutFile test_config/set_horton_env_vars.sh
   displayName: Create Azure Resources and Test Config

--- a/vsts/templates/steps-destroy-azure-resources.yaml
+++ b/vsts/templates/steps-destroy-azure-resources.yaml
@@ -1,9 +1,20 @@
+parameters:
+  # Must resolve to the same value as the resourceGroupName parameter in
+  # steps-create-azure-resources.yaml -- both are assembled from the build id, which is
+  # identical across every stage of a run. Overriding one without the other would leave the
+  # provisioned group behind.
+  resourceGroupName: 'rg-iot-sdk-e2e-$(Build.BuildId)'
+
 steps:
 - checkout: none
 
+# Runs provisioned before the name became reproducible recorded a random name here, so it is
+# still consulted when present. It is only a fallback: a setup job that never published an
+# artifact is precisely the case this stage has to survive, so a missing one is not an error.
 - download: current
   artifact: test_config
   displayName: Download artifact (test config)
+  continueOnError: true
 
 - task: AzureCLI@2
   inputs:
@@ -12,9 +23,27 @@ steps:
     scriptLocation: 'inlineScript'
     inlineScript: |
       set -e
-      export AZURE_RESOURCE_GROUP=$(cat "$(Pipeline.Workspace)/test_config/azure-resource-group-name.txt")
+      AZURE_RESOURCE_GROUP="${{ parameters.resourceGroupName }}"
+
+      RECORDED_NAME_FILE="$(Pipeline.Workspace)/test_config/azure-resource-group-name.txt"
+      if [ -f "$RECORDED_NAME_FILE" ]; then
+        RECORDED_NAME=$(tr -d "[:space:]" < "$RECORDED_NAME_FILE")
+        if [ -n "$RECORDED_NAME" ]; then
+          AZURE_RESOURCE_GROUP="$RECORDED_NAME"
+        fi
+      fi
+
+      # A setup job cancelled before it created anything leaves nothing to delete.
+      # --output tsv pins the format: the default is configurable per agent (az config set
+      # core.output=...), and the casing of the boolean differs between formats.
+      GROUP_EXISTS=$(az group exists --name "$AZURE_RESOURCE_GROUP" --output tsv | tr "[:upper:]" "[:lower:]" | tr -d "[:space:]")
+      if [ "$GROUP_EXISTS" != "true" ]; then
+        echo "Resource group $AZURE_RESOURCE_GROUP does not exist; nothing to delete."
+        exit 0
+      fi
+
       echo "Deleting Azure resource group: $AZURE_RESOURCE_GROUP"
-      az group delete --name $AZURE_RESOURCE_GROUP --yes --no-wait
+      az group delete --name "$AZURE_RESOURCE_GROUP" --yes --no-wait
   displayName: Destroy Azure Resource Group
   condition: always()
 


### PR DESCRIPTION
The cleanup stage learned which resource group to delete by reading
test_config/azure-resource-group-name.txt, an artifact published by the setup
job. The name itself was a random GUID, so that artifact was the only record of
it. It is written before provisioning starts and published with
`condition: always()`, so an ordinary cancellation is covered, but the name still
has to survive the setup job: if that job's agent is lost or hard killed, nothing
is published, the download fails, and the group lives on until the scheduled
janitor sweeps it up to seven hours later (Remove-LeftoverAzureResourceGroups
runs every four hours and skips groups younger than three).

Assemble the name in the pipeline instead, from the build id, which is unique to
the run and readable from every stage. The setup template passes it to
New-AzIotTestEnvironment and the cleanup template derives the same value, so
cleanup depends on nothing the setup job produced.

The PowerShell module is deliberately untouched: the name is now composed by the
templates and handed to the scripts.

Notes for review:

- The prefix is now spelled in the templates as well as in
  Get-AzureResourceGroupNamePrefix, which the scheduled cleanup matches on. Both
  copies carry a comment pointing at the other; if that is too easy to drift, the
  alternative is a shared variables template pulled into all eight pipelines.
- The artifact is still written, and cleanup still prefers it when present, so
  re-running the cleanup stage of a build provisioned before this change (random
  name, recorded only there) still deletes the right group. The download becomes
  continueOnError: a missing artifact must not fail the job whose whole purpose is
  to clean up after a setup that did not finish.
- Cleanup now checks `az group exists` first, so a setup cancelled before it
  created anything reports "nothing to delete" instead of failing.
- Names change from rg-iot-sdk-e2e-<guid> to rg-iot-sdk-e2e-<buildid>. The janitor
  matches on the prefix, so it is unaffected.
- A stage re-run within one build reuses the name by design; that is what lets
  cleanup find the group. Re-queuing produces a new build id and a new name.

Verified by extracting the cleanup script from the template and running it against
a stubbed az: with no artifact it deletes the name derived from the build id; with
no artifact and no group it exits 0 reporting nothing to delete; with a legacy
artifact it deletes the recorded random name; with a blank artifact it falls back
to the derived name. All touched YAML parses.