### PR TITLE
Make the gate test the PR, and pin the azure-iot CLI extension

### DIFF
--- a/scripts/Azure.Iot.Sdk.Test.psm1
+++ b/scripts/Azure.Iot.Sdk.Test.psm1
@@ -138,6 +138,44 @@ function Stop-OnError {
     }
 }
 
+# The azure-iot CLI extension version this repo provisions with.
+#
+# Provisioning needs the `az iot adr` command group, which ships only in the
+# preview builds. 0.30.0 final dropped it, and because a final release outranks
+# its own pre-releases, `--allow-preview` started resolving to 0.30.0 instead
+# of 0.30.0b2 -- so the command group disappeared with no change on our side and
+# every provisioning run began failing with:
+#
+#   ERROR: 'adr' is misspelled or not recognized by the system.
+#
+# Pinning is what makes this reproducible: `--allow-preview` selects whatever
+# happens to be newest, which is not a version this repo ever tested against.
+# TODO: drop the pin and install the stable extension once `adr` ships in one.
+$script:AzureIotCliExtensionVersion = "0.30.0b2"
+
+function Install-AzureIotCliExtension {
+    $Extension = $(az extension list --output json --only-show-errors | ConvertFrom-Json | ?{$_.name -eq "azure-iot"})
+
+    if ($null -ne $Extension -and $Extension.version -ne $script:AzureIotCliExtensionVersion) {
+        Write-Host "Azure IoT extension $($Extension.version) found; removing (pinned to $($script:AzureIotCliExtensionVersion))."
+        az extension remove --name azure-iot --only-show-errors | Out-Null
+        Stop-OnError -Step "Remove Azure IoT extension"
+        $Extension = $null
+    }
+
+    if ($null -eq $Extension) {
+        Write-Host "Installing Azure IoT extension $($script:AzureIotCliExtensionVersion)."
+        az extension add --name azure-iot --version $script:AzureIotCliExtensionVersion --allow-preview --only-show-errors | Out-Null
+        Stop-OnError -Step "Install Azure IoT extension"
+    }
+
+    # What actually ended up installed. When a provisioning command goes missing
+    # ("'adr' is misspelled or not recognized"), this is the first thing worth
+    # seeing in the log.
+    Write-Host "Azure CLI IoT extension version details:"
+    az extension list --output table --only-show-errors
+}
+
 function Invoke-WithRetry {
     <#
     .SYNOPSIS
@@ -1775,25 +1813,8 @@ function New-AzIotTestEnvironment {
         Stop-OnError -Step "Set Azure subscription"
     }
 
-    # Add Azure IoT extension if not already added (required for some az iot commands, e.g. az iot adr ns create)
-    # TODO: install non-preview version after GA.
-    $AzCliAzureIotExtension = $(az extension list | Convertfrom-json | ?{$_.name -eq "azure-iot"})
-
-    if ($null -ne $AzCliAzureIotExtension -and $AzCliAzureIotExtension.preview -eq $false) {
-        Write-Host "Non-preview Azure IoT extension found (version $($AzCliAzureIotExtension.version)). Removing..."
-        az extension remove --name azure-iot --only-show-errors | Out-Null
-        Stop-OnError -Step "Remove non-preview Azure IoT extension"
-        $AzCliAzureIotExtension = $null
-    }
-
-    if ($null -eq $AzCliAzureIotExtension) {
-        Write-Host "Installing Azure IoT extension."
-        az extension add --name azure-iot --allow-preview --only-show-errors | Out-Null
-        Stop-OnError -Step "Install Azure IoT extension"
-    }
-
-    Write-Host "Azure CLI IoT extension version details:"
-    az extension list
+    # Required for some az iot commands, e.g. az iot adr ns create.
+    Install-AzureIotCliExtension
 
     # Add default Azure resource group tags 
     if ($ResourceGroupTags -eq $null) {
@@ -2193,22 +2214,8 @@ function Get-AzIotTestEnvironment {
         Stop-OnError -Step "Set Azure subscription"
     }
 
-    # Add Azure IoT extension if not already added (required for some az iot commands, e.g. az iot adr ns create)
-    # TODO: install non-preview version after GA.
-    $AzCliAzureIotExtension = $(az extension list | Convertfrom-json | ?{$_.name -eq "azure-iot"})
-
-    if ($null -ne $AzCliAzureIotExtension -and $AzCliAzureIotExtension.preview -eq $false) {
-        Write-Host "Non-preview Azure IoT extension found (version $($AzCliAzureIotExtension.version)). Removing..."
-        az extension remove --name azure-iot --only-show-errors | Out-Null
-        Stop-OnError -Step "Remove non-preview Azure IoT extension"
-        $AzCliAzureIotExtension = $null
-    }
-
-    if ($null -eq $AzCliAzureIotExtension) {
-        Write-Host "Installing Azure IoT extension."
-        az extension add --name azure-iot --allow-preview --only-show-errors | Out-Null
-        Stop-OnError -Step "Install Azure IoT extension"
-    }
+    # Required for some az iot commands, e.g. az iot adr ns create.
+    Install-AzureIotCliExtension
 
     $AzureResourceGroup = az group show --name "$ResourceGroup" | ConvertFrom-Json
 

--- a/vsts/templates/steps-create-azure-resources.yaml
+++ b/vsts/templates/steps-create-azure-resources.yaml
@@ -2,8 +2,6 @@ parameters:
   azure_location: 'centraluseuap'
 
 steps:
-- checkout: none
-
 - template: steps-ensure-e2e-fx-repo.yaml
 
 - task: AzureCLI@2

--- a/vsts/templates/steps-ensure-e2e-fx-repo.yaml
+++ b/vsts/templates/steps-ensure-e2e-fx-repo.yaml
@@ -1,14 +1,33 @@
 steps:
 - bash: |
+    set -e
+
     if [ -f "${HORTON_FRAMEWORKROOT}/bin/horton" ]; then
       echo "e2e-fx framework already present at ${HORTON_FRAMEWORKROOT}"
-      git -C ${HORTON_FRAMEWORKROOT} log -1 --oneline
-    else
-      mkdir -p ${HORTON_FRAMEWORKROOT} &&
-      cd ${HORTON_FRAMEWORKROOT} &&
-      git clone https://github.com/Azure/iot-sdks-e2e-fx . &&
-      git checkout $(Horton.FrameworkRef) &&
-      git log -1 --oneline
+      git -C "${HORTON_FRAMEWORKROOT}" log -1 --oneline
+      exit 0
     fi
-  displayName: "Clone e2efx repo"
 
+    # Only reached by a job that checks out no sources of its own.
+    #
+    # Horton.FrameworkRef names the ref to test. While it was undefined, Azure
+    # Pipelines left the literal "$(Horton.FrameworkRef)" in the script, bash
+    # treated it as command substitution, and `git checkout` ran with an empty
+    # argument -- which succeeds and leaves the clone on master. That is how
+    # create_azure_resources came to provision with master instead of the code
+    # under test, for every PR, without anything going red. Refuse to guess.
+    case "${HORTON_FRAMEWORKREF}" in
+      ""|'$('*)
+        echo "ERROR: Horton.FrameworkRef is not set, so there is no way to tell" >&2
+        echo "       which e2e-fx ref this job should run. Either let the job" >&2
+        echo "       check out sources, or set Horton.FrameworkRef." >&2
+        exit 1
+        ;;
+    esac
+
+    mkdir -p "${HORTON_FRAMEWORKROOT}"
+    cd "${HORTON_FRAMEWORKROOT}"
+    git clone https://github.com/Azure/iot-sdks-e2e-fx .
+    git checkout "${HORTON_FRAMEWORKREF}"
+    git log -1 --oneline
+  displayName: "Clone e2efx repo"


### PR DESCRIPTION
Two changes that can only be verified together, so they ship together. They remain separate commits — [`dc89cc1`](https://github.com/Azure/iot-sdks-e2e-fx/commit/dc89cc1) makes the gate test the PR, [`dfc9c0e`](https://github.com/Azure/iot-sdks-e2e-fx/commit/dfc9c0e) pins the extension — and can be reviewed independently.

## Why they're combined

They deadlock each other:

- **The gate fix alone** makes `create_azure_resources` provision from the branch under test instead of master. But this branch's module had no pin, so the build still failed.
- **The pin alone** never ran in its own build, because the gate provisions from **master's** module — which doesn't have it yet.

Either one on its own is correct and permanently red. Together the gate is **green** (build 161471, 13/13 identity tasks, no failed task anywhere). Merging one red to unblock the other would have meant landing an unverified change, so they're one PR instead.

---

# 1. The gate build tests master, not the PR

`create_azure_resources` has been provisioning with **master's** `Azure.Iot.Sdk.Test.psm1` rather than the pull request's, for every gate build, since May.

The job carries `checkout: none`, so nothing is checked out and the file-existence probe in `steps-ensure-e2e-fx-repo.yaml` falls through to the clone path, which ends in:

```bash
git checkout $(Horton.FrameworkRef)
```

`Horton.FrameworkRef` **is defined nowhere in this repo and never has been** — it arrived dead in the "major script rewrite". Azure Pipelines leaves an undefined `$(...)` in the script verbatim, bash reads it as command substitution, and the job logs:

```
line 8: Horton.FrameworkRef: command not found
Your branch is up to date with 'origin/master'
```

`git checkout` with an empty argument **succeeds**, so the `&&` chain never breaks and the clone stays on master. Nothing goes red. The build reports a result for code that is not under review.

`checkout: none` was added to *"skip the unnecessary SDK checkout"*, but these pipelines declare **no repository resources** — `self` is this repo, exactly what the job needs. Before that change the clone was guarded by a condition that was always false, so the checked-out sources were used. Removing `checkout: none` restores that.

The clone path stays for any job that genuinely checks out nothing, but it no longer guesses: an unset ref, or one still holding an unexpanded `$(...)`, now fails the step with an explanation.

Verified against the step body extracted from the yaml:

```
case 1: sources already present      -> PASS (short-circuits, no clone)
case 2: no sources, ref unset        -> PASS (fails, refused to guess)
case 3: no sources, ref a raw macro  -> PASS (fails, refused to guess)
```

---

# 2. Pin the azure-iot CLI extension

The hosted agents ship **azure-iot `0.32.0b1`** preinstalled at `C:\Program Files\Common Files\AzureCliExtensionDirectory`. That version is **newer than anything in the public extension index** (which tops out at `0.30.0`), so it can't be reached by `az extension add` and was never what this repo tested against. It broke provisioning twice.

### `az iot adr` is missing

```
ERROR: 'adr' is misspelled or not recognized by the system.
```

`az iot adr` ships only in preview builds. `0.30.0` final doesn't have it, and because a final release outranks its own pre-releases, `--allow-preview` resolves to `0.30.0` rather than `0.30.0b2`.

### Service connection strings address the *device* endpoint

Every gate build failed at `Create new identites and deploy containers` with a bare `Bad Request`. The reason IoT Hub gives, which the log was discarding:

```
errorCode 400000: The requested operation is not supported on this hostname.
Use the device endpoint for device hostname and the service hostname for service operations.
```

`az iot hub connection-string show --policy-name iothubowner` returns the TLS 1.3 preview **device** hostname under `0.32.0b1` — a *service* credential pointed at a device-only endpoint. Measured on the same hub, varying only the CLI:

| azure-iot | `connection-string show` (iothubowner) |
| --- | --- |
| none (core az) | `<hub>.device.azure-devices.net` |
| 0.30.0b2 | `<hub>.azure-devices.net` |
| 0.30.0 | `<hub>.azure-devices.net` |
| **0.32.0b1** (agent) | **`<hub>.device.azure-devices.net`** |

**The hub is correct in every case** — `properties.hostName` is classic, `properties.deviceHostName` is the device one, exactly as the [TLS 1.3 preview](https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-tls-support#tls-13-support-preview) documents. This is a CLI extension bug, not a service one, and worth reporting separately.

### Why pinning alone wasn't enough

The removal condition only replaced the extension when the installed one was *non-preview*:

```powershell
if ($ext -ne $null -and $ext.preview -eq $false) { remove }
```

`0.32.0b1` **is** preview, so it was kept and `az extension add` was a no-op — the pin could never hold. It's now *"remove anything that is not the pinned version"*, so a runner that cached the wrong version repairs itself.

### Also in here

- The install logic moves into a single `Install-AzureIotCliExtension`; it was duplicated verbatim in `New-AzIotTestEnvironment` and `Get-AzIotTestEnvironment`.
- #427's version logging moves in with it — it was only in the `New-` path. That logging is what made this diagnosable.
- Both `az extension list` calls request an explicit output format. The default is user-configurable (`core.output`), so under `core.output=table` the parsed call fed a table into `ConvertFrom-Json` and threw — breaking provisioning even when the extension was installed correctly.

---

## Verification

| Build | Contents | Result |
| --- | --- | --- |
| 161466 | diagnostic, agent CLI | extension `0.32.0b1`, connection string **device** |
| 161469 | diagnostic + pin | extension `0.30.0b2`, connection string **classic** |
| **161471** | **this PR, full gate** | **green — 13/13 identity tasks, 0 failed tasks** |

Once this reaches master, every repo that downloads the module at runtime is fixed too, including the C SDK's `ci-c-e2e-csr`.

Supersedes #430 and #433.
