### PR TITLE
Make the gate build test the PR's framework, not master's

### DIFF
--- a/vsts/templates/steps-create-azure-resources.yaml
+++ b/vsts/templates/steps-create-azure-resources.yaml
@@ -2,8 +2,6 @@ parameters:
   azure_location: 'centraluseuap'
 
 steps:
-- checkout: none
-
 - template: steps-ensure-e2e-fx-repo.yaml
 
 - task: AzureCLI@2

--- a/vsts/templates/steps-ensure-e2e-fx-repo.yaml
+++ b/vsts/templates/steps-ensure-e2e-fx-repo.yaml
@@ -1,14 +1,33 @@
 steps:
 - bash: |
+    set -e
+
     if [ -f "${HORTON_FRAMEWORKROOT}/bin/horton" ]; then
       echo "e2e-fx framework already present at ${HORTON_FRAMEWORKROOT}"
-      git -C ${HORTON_FRAMEWORKROOT} log -1 --oneline
-    else
-      mkdir -p ${HORTON_FRAMEWORKROOT} &&
-      cd ${HORTON_FRAMEWORKROOT} &&
-      git clone https://github.com/Azure/iot-sdks-e2e-fx . &&
-      git checkout $(Horton.FrameworkRef) &&
-      git log -1 --oneline
+      git -C "${HORTON_FRAMEWORKROOT}" log -1 --oneline
+      exit 0
     fi
-  displayName: "Clone e2efx repo"
 
+    # Only reached by a job that checks out no sources of its own.
+    #
+    # Horton.FrameworkRef names the ref to test. While it was undefined, Azure
+    # Pipelines left the literal "$(Horton.FrameworkRef)" in the script, bash
+    # treated it as command substitution, and `git checkout` ran with an empty
+    # argument -- which succeeds and leaves the clone on master. That is how
+    # create_azure_resources came to provision with master instead of the code
+    # under test, for every PR, without anything going red. Refuse to guess.
+    case "${HORTON_FRAMEWORKREF}" in
+      ""|'$('*)
+        echo "ERROR: Horton.FrameworkRef is not set, so there is no way to tell" >&2
+        echo "       which e2e-fx ref this job should run. Either let the job" >&2
+        echo "       check out sources, or set Horton.FrameworkRef." >&2
+        exit 1
+        ;;
+    esac
+
+    mkdir -p "${HORTON_FRAMEWORKROOT}"
+    cd "${HORTON_FRAMEWORKROOT}"
+    git clone https://github.com/Azure/iot-sdks-e2e-fx .
+    git checkout "${HORTON_FRAMEWORKREF}"
+    git log -1 --oneline
+  displayName: "Clone e2efx repo"


### PR DESCRIPTION
`create_azure_resources` has been provisioning with **master's** copy of `Azure.Iot.Sdk.Test.psm1` rather than the one in the pull request — for every gate build, since May.

## What happens

The job carries `checkout: none`, so nothing is checked out and the file-existence probe in `steps-ensure-e2e-fx-repo.yaml` falls through to the clone path, which ends in:

```bash
git checkout $(Horton.FrameworkRef)
```

`Horton.FrameworkRef` **is defined nowhere in this repo and never has been** — it arrived dead in the "major script rewrite". Azure Pipelines leaves an undefined `$(...)` in the script verbatim, bash reads it as command substitution, and the job logs:

```
line 8: Horton.FrameworkRef: command not found
Your branch is up to date with 'origin/master'
cc06001 Log Azure CLI IoT extension version details (#427)
```

`git checkout` with an empty argument **succeeds**, so the `&&` chain never breaks and the clone simply stays on master. Nothing goes red. The build reports success or failure for code that is not under review.

Seen live in build 161430, where the provisioning step logged master's `Installing Azure IoT extension.` instead of the versioned message that build's PR (#428) adds.

## Why `checkout: none` was wrong

It was added to *"skip the unnecessary SDK checkout"* — but these pipelines declare **no repository resources**, so `self` is this repo, which is exactly what the job needs.

Before that change the clone was guarded by `ne(Build.SourcesDirectory, Horton.FrameworkRoot)`, which is always false since every gate sets `Horton.FrameworkRoot: $(Build.SourcesDirectory)`. So the clone never ran and the checked-out sources were used — correct. Removing `checkout: none` restores that, and the existing file-existence probe now short-circuits for the same reason.

## The clone path no longer guesses

It stays for any job that genuinely checks out nothing, but an unset ref — or one still holding an unexpanded `$(...)` — now fails the step with an explanation instead of quietly running master.

Verified against the step body extracted from the yaml, so the test exercises what actually ships:

```
== case 1: sources already present -> short-circuit, no clone ==
PASS  present (rc=0)
== case 2: no sources, ref unset -> must FAIL, not silently use master ==
PASS  unset ref (rc=1)          -> refused to guess
== case 3: no sources, ref left as an unexpanded macro -> must FAIL ==
PASS  literal macro (rc=1)      -> refused to guess
```

Case 3 is the state this has been in all along.

## Effect on in-flight PRs

Once this merges, gate builds start provisioning with the branch under test. #428 is the immediate beneficiary: it changes the extension install and currently cannot be validated by its own gate.
