### PR TITLE
Resolve commit SHAs with git ls-remote instead of the GitHub API

### DIFF
--- a/bin/build/github.py
+++ b/bin/build/github.py
@@ -1,46 +1,47 @@
 # Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license tagsrmation.
-import requests
+import os
+import subprocess
 
 
 def get_sha_from_commit(repo, commit):
     """
     given a GIT repo and a commit ID, return the SHA for that commit
+
+    This resolves the ref over the git protocol rather than through
+    api.github.com.  The REST API allows only 60 anonymous requests per hour
+    per source IP, shared by every job running on that hosted agent, so a busy
+    hour exhausts the budget and the build dies with a 403 that has nothing to
+    do with the change under test.  git ls-remote is not part of that budget
+    and needs no credential for a public repo, so there is no token to issue,
+    authorize, rotate or expire.
     """
     if not commit.startswith("refs/"):
         commit = "refs/heads/" + commit
-    response = requests.get(
-        "https://api.github.com/repos/{}/git/{}".format(repo, commit)
-    )
-    if response.status_code == 200:
-        return response.json()["object"]["sha"]
-    elif response.status_code == 404:
-        raise Exception("ERROR : Commit {} not found in repo {}".format(commit, repo))
-    else:
+
+    url = "https://github.com/{}".format(repo)
+    # A repo that is missing or private makes git ask for credentials on the
+    # terminal, which would hang the build rather than fail it.
+    env = dict(os.environ, GIT_TERMINAL_PROMPT="0")
+    try:
+        output = subprocess.check_output(
+            ["git", "ls-remote", url, commit],
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            env=env,
+        )
+    except subprocess.CalledProcessError as e:
         raise Exception(
-            "unexpected result looking for commit {} in repo {} status = {} response = {}".format(
-                commit, repo, response.status_code, response.json()
+            "ERROR : could not reach repo {} to resolve {}: {}".format(
+                repo, commit, e.output.strip()
             )
         )
 
+    # Output is "<sha>\t<ref>" per line.  Match the ref exactly: ls-remote
+    # treats its argument as a pattern, so a loose one could return several.
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) == 2 and parts[1] == commit:
+            return parts[0]
 
-def get_sha_url_and_ref_from_prid(repo, prid):
-    """
-    given a GIT repo and a pull request ID, return the SHA, clone_url, and ref for that pull request
-    """
-    response = requests.get(
-        "https://api.github.com/repos/{}/pulls/{}".format(repo, prid)
-    )
-    if response.status_code == 200:
-        sha = response.json()["head"]["sha"]
-        url = response.json()["head"]["repo"]["clone_url"]
-        ref = response.json()["head"]["ref"]
-        return (sha, url, ref)
-    elif response.status_code == 405:
-        raise Exception("ERROR : prid {} not found in repo {}".format(prid, repo))
-    else:
-        raise Exception(
-            "unexpected result looking for prid {} in repo {} status = {} response = {}".format(
-                prid, repo, response.status_code, response.json()
-            )
-        )
+    raise Exception("ERROR : Commit {} not found in repo {}".format(commit, repo))

--- a/vsts/templates/steps-build-docker-image.yaml
+++ b/vsts/templates/steps-build-docker-image.yaml
@@ -214,23 +214,22 @@ steps:
     NODE_BRANCH="main"
 
     echo "Resolving commit SHA for ${NODE_REPO} @ ${NODE_BRANCH}..."
-    # The GitHub API call can transiently fail or be rate-limited, returning a
-    # non-JSON (or empty) body that crashes json.load.  Retry with backoff and
-    # use an auth token when available to raise the rate limit.
-    AUTH_HEADER=()
-    if [ -n "${GITHUB_TOKEN}" ]; then
-      AUTH_HEADER=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
-    fi
+    # Resolve over the git protocol, not api.github.com.  The REST API allows
+    # only 60 anonymous requests per hour per source IP, shared by every job on
+    # the hosted pool, and the build then dies with a 403 that has nothing to do
+    # with the change under test.  git ls-remote is not part of that budget and
+    # needs no credential for a public repo.  Still retried, because the network
+    # can blip.
+    #
+    # GIT_TERMINAL_PROMPT=0 so an unreachable repo fails instead of blocking on
+    # a credential prompt nobody can answer.
     COMMIT_SHA=""
     for attempt in 1 2 3 4 5; do
-      RESPONSE=$(curl -s "${AUTH_HEADER[@]}" "https://api.github.com/repos/${NODE_REPO}/git/refs/heads/${NODE_BRANCH}" || true)
-      COMMIT_SHA=$(echo "${RESPONSE}" | python3 -c "import sys,json; print(json.load(sys.stdin)['object']['sha'])" 2>/dev/null || true)
+      COMMIT_SHA=$(GIT_TERMINAL_PROMPT=0 git ls-remote "https://github.com/${NODE_REPO}" "refs/heads/${NODE_BRANCH}" | awk 'NR==1 {print $1}' || true)
       if [ -n "${COMMIT_SHA}" ]; then
         break
       fi
-      echo "Attempt ${attempt}: could not resolve commit SHA. Response was:" >&2
-      echo "${RESPONSE}" | head -c 500 >&2
-      echo "" >&2
+      echo "Attempt ${attempt}: could not resolve ${NODE_BRANCH} in ${NODE_REPO}." >&2
       sleep $((attempt * 10))
     done
     if [ -z "${COMMIT_SHA}" ]; then


### PR DESCRIPTION
`horton build` resolves a branch to a commit SHA to tag docker images, and it did so through `api.github.com`. Anonymous REST calls are capped at **60 per hour per source IP**, shared by every job on the hosted pool, so a busy hour exhausts the budget and the build dies with a 403 that has nothing to do with the change under test. Build 161476:

```
Exception: unexpected result looking for commit refs/heads/main in repo Azure/azure-iot-sdk-node
status = 403 response = {'message': "API rate limit exceeded for 20.184.191.96. ..."}
```

## Why not a token

That was this PR's first approach, and it was the wrong one.

Authenticating means issuing a token, storing it as a pipeline secret, and rotating it — operational weight, plus coupling CI to whoever's account minted it. An ADO **GitHub service connection** would avoid the per-user coupling, but it can't be used here: service connections are only consumable by tasks that declare a `connectedService` input, and there's no equivalent of `AzureCLI@2` for GitHub. A plain bash or python step cannot borrow those credentials. You could force it — `persistCredentials: true` and scrape `http.https://github.com/.extraheader` — but that drags a credential into script space.

None of it is necessary. **`git ls-remote` returns the same SHA over the git protocol**, which is not part of the REST budget and needs no credential for a public repo. Nothing to issue, authorize, rotate or expire.

```
git ls-remote https://github.com/Azure/azure-iot-sdk-node refs/heads/main
  -> d29f0f57dc372f6a8ce02de720bb4f7567954aae
api.github.com/repos/.../git/refs/heads/main
  -> d29f0f57dc372f6a8ce02de720bb4f7567954aae
```

## What changed

Both call sites move over: `get_sha_from_commit`, and the `default-friend-module` step, which was making the same lookup with `curl`.

`get_sha_url_and_ref_from_prid` is **deleted** rather than converted. It has no callers anywhere in the repo — the only other reference was a stale `.pyc` — and it's the one lookup that genuinely needs the REST API, for a fork's `clone_url`. Keeping dead code that would reintroduce the rate limit isn't worth it; it can come back, authenticated, if something ever needs it.

`GIT_TERMINAL_PROMPT=0` at both call sites: a missing or private repo makes git ask for credentials on the terminal, which would **hang** the build rather than fail it.

## Verification

Against live repos:

| case | result |
| --- | --- |
| bare branch name `main` | `d29f0f5…`, identical to the REST API |
| full ref `refs/heads/main` | identical |
| second repo (`azure-iot-sdk-c`) | resolves |
| tag ref | resolves to the same sha as `ls-remote` |
| missing branch | `Commit ... not found in repo ...` |
| missing repo | fails in 0.9s, no credential prompt |

The bash path was checked the same way, including that an unresolvable repo leaves the retry loop intact under `set -e` rather than aborting the step. flake8 and black clean; the yaml still parses.

## Note on the gate

A green gate here doesn't prove much either way — the 403 is intermittent, so passing could just mean the window had reset. The evidence for this change is the equivalence above, not the build result.
