### PR TITLE
Surface IoT Hub's own explanation when a service call is rejected

### DIFF
--- a/horton_helpers/src/iothub_service_helper.py
+++ b/horton_helpers/src/iothub_service_helper.py
@@ -15,6 +15,30 @@ import connection_string
 import time
 
 
+def _add_service_detail(e):
+    """Fold the service's own explanation into an HttpOperationError message.
+
+    msrest builds its message from the HTTP status alone, so a rejected
+    request surfaces as nothing more than "Operation returned an invalid
+    status code 'Bad Request'".  IoT Hub does say what was wrong, but only in
+    the response body, which never reaches the log -- leaving a failed build
+    with no way to tell a malformed device id from a hub that is out of quota.
+
+    The exception is modified in place rather than replaced: try_delete_device
+    and friends catch HttpOperationError to ignore "not found", so changing the
+    type here would stop those from working.  Callers that swallow the error
+    still print nothing.
+    """
+    body = getattr(getattr(e, "response", None), "text", None)
+    body = body.strip() if body else ""
+    if not body:
+        return
+    detail = "{} -- service said: {}".format(str(e), body)
+    e.args = (detail,) + tuple(e.args[1:])
+    if hasattr(e, "message"):
+        e.message = detail
+
+
 def _retry_transient(fn, retries=5, initial_delay=2):
     """Retry an IoT Hub service call on transient errors.
 
@@ -57,6 +81,7 @@ def _retry_transient(fn, retries=5, initial_delay=2):
                 time.sleep(delay)
                 delay = min(delay * 2, 30)
                 continue
+            _add_service_detail(e)
             raise
     if last_error:
         raise last_error


### PR DESCRIPTION
`Create new identites and deploy containers` has been failing across gate builds with nothing more useful than:

```
msrest.exceptions.HttpOperationError: Operation returned an invalid status code 'Bad Request'
```

msrest builds that message from the **HTTP status alone**. IoT Hub does say what was wrong with the request, but only in the response body — which never reaches the log. So there's no way to tell a malformed device id from a hub that's out of quota without reproducing by hand.

## Before / after

```
--- what the log used to show ---
  Operation returned an invalid status code 'Bad Request'

--- what it shows now ---
  Operation returned an invalid status code 'Bad Request' -- service said:
  {"Message":"ErrorCode:ArgumentInvalid;Invalid device identity name.",
   "ExceptionMessage":"Tracking ID:abc-Time:2026-08-05"}
```

> **This does not fix the Bad Request.** It makes the next occurrence diagnosable from the build log, which is the part that's currently impossible. Same reasoning as #422 for the Azure CLI's stderr.

## Why the exception is modified in place, not replaced

`try_delete_device` and `try_delete_module` catch `HttpOperationError` to ignore "not found". Raising a different type here would silently stop those from working — they'd start propagating errors they are written to swallow. My first attempt did exactly that; the tests below are what caught it.

Callers that swallow the error still print nothing, so this adds no noise to the normal path.

## Verification

Built on a real `requests.Response`, since msrest reaches into the response object:

```
PASS  400 keeps HttpOperationError type
PASS  400 message now carries the service reason
PASS  400 is not retried
PASS  callers can still catch HttpOperationError
PASS  503 still retried
PASS  empty body leaves the message alone
PASS  missing response is tolerated
```
