### PR TITLE
Put the iothubowner connection string back on the classic endpoint

### DIFF
--- a/scripts/Azure.Iot.Sdk.Test.psm1
+++ b/scripts/Azure.Iot.Sdk.Test.psm1
@@ -138,6 +138,41 @@ function Stop-OnError {
     }
 }
 
+function ConvertTo-ServiceHostName {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string] $ConnectionString)
+
+    # `az iot hub connection-string show` can hand back the TLS 1.3 preview
+    # DEVICE endpoint (<hub>.device.azure-devices.net) instead of the classic
+    # one, and IoT Hub rejects service operations sent there:
+    #
+    #   errorCode 400000: The requested operation is not supported on this
+    #   hostname. Use the device endpoint for device hostname and the service
+    #   hostname for service operations.
+    #
+    # Measured on hubs created in centraluseuap with the same --mintls 1.2
+    # this module uses, varying only the CLI:
+    #
+    #   no azure-iot extension  -> <hub>.device.azure-devices.net
+    #   azure-iot 0.30.0b2      -> <hub>.azure-devices.net
+    #   azure-iot 0.30.0        -> <hub>.azure-devices.net
+    #
+    # So it is the CORE az implementation that returns the device endpoint; the
+    # extension overrides the command and returns the classic hostname. In the
+    # pipeline the extension is installed and demonstrably active for other
+    # commands, yet this one still produced the device endpoint -- it emits no
+    # "behavior has been altered by the following extension" warning, so it is
+    # not being overridden there. The hub itself is fine either way:
+    # properties.hostName is the classic hostname in every case measured.
+    #
+    # Normalising here makes provisioning independent of which az resolves the
+    # command.
+    if ([string]::IsNullOrWhiteSpace($ConnectionString)) {
+        return $ConnectionString
+    }
+
+    return ($ConnectionString -replace '(?i)\.device\.azure-devices\.net', '.azure-devices.net')
+}
+
 function Invoke-WithRetry {
     <#
     .SYNOPSIS
@@ -2107,7 +2142,7 @@ function New-AzIotTestEnvironment {
     $TestEnvInfo.AzureAdrPolicyName = $AzureAdrPolicyName
 
     Write-Host "Getting IoT Hub Connection String"
-    $TestEnvInfo.IotHub.ConnectionString = $(az iot hub connection-string show -g $ResourceGroup -n $IotHubName --kt primary --pn iothubowner --query connectionString -o tsv)
+    $TestEnvInfo.IotHub.ConnectionString = ConvertTo-ServiceHostName $(az iot hub connection-string show -g $ResourceGroup -n $IotHubName --kt primary --pn iothubowner --query connectionString -o tsv)
     Stop-OnError -Step "Get IoT Hub Connection String"
 
     Write-Host "Getting IoT Hub's Event Hub Connection String"
@@ -2251,7 +2286,7 @@ function Get-AzIotTestEnvironment {
     }
 
     Write-Host "Getting IoT Hub Connection String"
-    $TestEnvInfo.IotHub.ConnectionString = $(az iot hub connection-string show -g $ResourceGroup -n $IotHubName --kt primary --pn iothubowner --query connectionString -o tsv)
+    $TestEnvInfo.IotHub.ConnectionString = ConvertTo-ServiceHostName $(az iot hub connection-string show -g $ResourceGroup -n $IotHubName --kt primary --pn iothubowner --query connectionString -o tsv)
     Stop-OnError -Step "Get IoT Hub Connection String"
 
     Write-Host "Getting IoT Hub's Event Hub Connection String"


### PR DESCRIPTION
Every gate build has been failing since ~02:00 UTC on 2026-08-05 — **on master and on every branch** — at `Create new identites and deploy containers`, with only this in the log:

```
msrest.exceptions.HttpOperationError: Operation returned an invalid status code 'Bad Request'
```

IoT Hub's actual explanation was being discarded:

```
errorCode 400000: The requested operation is not supported on this hostname.
Use the device endpoint for device hostname and the service hostname for service operations.
```

## This is the TLS 1.3 endpoint preview, and it is behaving incorrectly

IoT Hub's TLS 1.3 preview adds two endpoints alongside the classic one ([docs](https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-tls-support#tls-13-support-preview)):

| Endpoint | Hostname | TLS |
| --- | --- | --- |
| Classic | `<hub>.azure-devices.net` | 1.2 |
| Device (preview) | `<hub>.device.azure-devices.net` | 1.2 restricted + 1.3 |
| Service (preview) | `<hub>.service.azure-devices.net` | 1.2 restricted + 1.3 |

The documentation is explicit that these are **"additive, not a replacement"**, that *"there's no planned change to the existing IoT Hub endpoint"*, and that the classic endpoint *"remains fully supported and continues to be the default for existing workloads"*. Adoption is *"optional and customer-controlled"*. The documented way to read them back is:

```azurecli
az iot hub show --query "{classic:properties.hostName, device:properties.deviceHostName}"
```

— i.e. **`properties.hostName` is supposed to stay classic**, with the device endpoint exposed separately as `properties.deviceHostName`.

That is not what the service returns. `properties.hostName` now hands back the **device** endpoint. Nothing here opted in: the hub is created with a plain `az iot hub create`.

`az iot hub connection-string show` copies that hostname verbatim (`hostname = hub.properties.host_name` in `azext_iot/operations/hub.py` — I diffed it between azure-iot `0.30.0b2` and `0.30.0` and it is **identical**, so this is not a CLI-version issue). The result is an `iothubowner` connection string that no service SDK can use, so device creation fails before a single test runs.

**Not a regression in this repo:** it reproduces on master (build 161442), the last green master build (161422, 00:36 UTC) predates it by two hours with no repo change between, and it also hit `timtay-microsoft-patch-3` (161425).

## The change

`iothubowner` connection strings are put back on the classic endpoint. Device connection strings are left alone — the device endpoint is valid for those.

Two properties worth noting:

- **It is a no-op once the service is corrected.** The rewrite only fires when the device label is present, so this can stay in place safely and be removed on its own schedule.
- **There is a better fix, once it exists.** The documented `--hostname-type classic` parameter is absent from both `0.30.0b2` and `0.30.0`; the docs are ahead of the shipped CLI. When it lands, asking for `classic` explicitly replaces this string surgery. That's noted in the code.

## Verification

| Build | Contents | Identity tasks | Result |
| --- | --- | --- | --- |
| 161444 | without this fix | **0/13** | failed |
| 161448 | with this fix | **13/13** | succeeded |
| 161453 | this PR | **13/13** | **succeeded, no failed task anywhere** |

Unit cases: device endpoint rewritten; classic left untouched (the no-op case above); empty string tolerated; a shared access key containing the literal is not corrupted.

## Region

The gate provisions in **`centraluseuap`** — `steps-create-azure-resources.yaml` defaults `azure_location` to it and `gate-horton.yaml` does not override it. To be precise about evidence: that is config-level, not log-level — the provisioning step doesn't print the region. Canary is the expected place for a preview rollout to land first, and public regions aren't showing this.

## Why this is stacked on #430

Without #430, `create_azure_resources` provisions using **master's** copy of the module rather than the PR's, so this fix wouldn't be exercised by its own gate build — the PR would be correct and permanently red. #430 is what makes it verifiable.
