### PR TITLE
Stop the extension version log from leaking into the caller's return value

### DIFF
--- a/scripts/Azure.Iot.Sdk.Test.psm1
+++ b/scripts/Azure.Iot.Sdk.Test.psm1
@@ -172,8 +172,18 @@ function Install-AzureIotCliExtension {
     # What actually ended up installed. When a provisioning command goes missing
     # ("'adr' is misspelled or not recognized"), this is the first thing worth
     # seeing in the log.
+    #
+    # Capture the table and re-emit it with Write-Host rather than letting the
+    # native command write straight to the pipeline. A bare `az` call puts its
+    # stdout on the SUCCESS stream, which flows out of this function and into
+    # the caller's return value -- New-AzIotTestEnvironment then returns
+    # Object[] (table lines + the TestEnvironmentInfo) instead of a single
+    # object, and any caller with a typed [TestEnvironmentInfo] parameter fails
+    # with "Cannot convert the System.Object[] value ... to TestEnvironmentInfo".
+    # Write-Host is also the only form that reliably reaches the log from inside
+    # the AzureCLI@2 task, which swallows bare native stdout.
     Write-Host "Azure CLI IoT extension version details:"
-    az extension list --output table --only-show-errors
+    Write-Host (az extension list --output table --only-show-errors | Out-String)
 }
 
 function Invoke-WithRetry {


### PR DESCRIPTION
`Install-AzureIotCliExtension` ends with a bare native call:

```powershell
az extension list --output table --only-show-errors
```

A native command's stdout goes to PowerShell's **success stream**, so those table lines flow out of the helper, into `New-AzIotTestEnvironment`, and onto its return value. The function returns `Object[]` — seven table lines plus the `TestEnvironmentInfo` — instead of a single object.

Callers that bind the result to a typed parameter then fail. The C SDK's csr provisioning dies with:

```
New-AzIotCSDKE2ETestConfig:
  Cannot process argument transformation on parameter 'TestEnvInfo'.
  Cannot convert the "System.Object[]" value of type "System.Object[]"
  to type "TestEnvironmentInfo".
```

## Why CI didn't catch it

The horton gate's consumers don't bind the result to a typed parameter, so the array passes through unnoticed. Master went green (build 161472) with the bug in place, and it only surfaced downstream in a consuming repo. Worth knowing that this module's own gate is blind to the shape of what these functions return.

## The fix

Capture the table and re-emit it with `Write-Host`. Keeps the logging, keeps the stream clean.

`Write-Host` is also the only form that reliably reaches the log from inside the `AzureCLI@2` task, which swallows bare native stdout — so as written, the line was polluting the return value *without even producing the log output it was added for*.

## Verification

Calling the helper directly and counting what reaches the output stream, same machine, same extension set:

| | objects leaked | caller returns |
| --- | --- | --- |
| before | **7** | `System.Object[]` (count 8) |
| after | **0** | `PSCustomObject` |

The "before" numbers reproduce the CI failure exactly. The extension table still appears in the log in both cases.

## Provenance

Introduced in #427, which added the bare `az extension list` inside `New-AzIotTestEnvironment`. #428 moved it into the shared helper, which preserved the behaviour and extended it to `Get-AzIotTestEnvironment`. Neither PR's gate could see it, for the reason above.

Unblocks `ci-c-e2e-csr` in Azure/azure-iot-sdk, which consumes this module from master at runtime.
