### PR TITLE
Move the IoT Edge runtime images from the EOL 1.4 line to 1.5

### DIFF
--- a/bin/deploy/edge_configuration.py
+++ b/bin/deploy/edge_configuration.py
@@ -33,12 +33,12 @@ class EdgeConfiguration:
         if len(os.environ.get("IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE", None) or "") > 0:
             self.agentImage = os.environ["IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE"]
         else:
-            self.agentImage = "mcr.microsoft.com/azureiotedge-agent:1.6"
+            self.agentImage = "mcr.microsoft.com/azureiotedge-agent:1.5"
 
         if len(os.environ.get("IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE", None) or "") > 0:
             self.hubImage = os.environ["IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE"]
         else:
-            self.hubImage = "mcr.microsoft.com/azureiotedge-hub:1.6"
+            self.hubImage = "mcr.microsoft.com/azureiotedge-hub:1.5"
 
         self.config = {
             "moduleContent": {

--- a/bin/deploy/edge_configuration.py
+++ b/bin/deploy/edge_configuration.py
@@ -30,22 +30,15 @@ class EdgeConfiguration:
             "password": os.environ["IOTHUB_E2E_REPO_PASSWORD"],
         }
 
-        if (
-            False
-            and len(os.environ.get("IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE", None) or "")
-            > 0
-        ):
+        if len(os.environ.get("IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE", None) or "") > 0:
             self.agentImage = os.environ["IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE"]
         else:
-            self.agentImage = "mcr.microsoft.com/azureiotedge-agent:1.4"
+            self.agentImage = "mcr.microsoft.com/azureiotedge-agent:1.6"
 
-        if (
-            False
-            and len(os.environ.get("IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE", None) or "") > 0
-        ):
+        if len(os.environ.get("IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE", None) or "") > 0:
             self.hubImage = os.environ["IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE"]
         else:
-            self.hubImage = "mcr.microsoft.com/azureiotedge-hub:1.4"
+            self.hubImage = "mcr.microsoft.com/azureiotedge-hub:1.6"
 
         self.config = {
             "moduleContent": {

--- a/vsts/templates/steps-pre-test.yaml
+++ b/vsts/templates/steps-pre-test.yaml
@@ -3,8 +3,8 @@ parameters:
   repo_address: $(IOTHUB-E2E-REPO-ADDRESS)
   repo_user: $(IOTHUB-E2E-REPO-USER)
   repo_password: $(IOTHUB-E2E-REPO-PASSWORD)
-  image_edgeHub: mcr.microsoft.com/azureiotedge-hub:1.4
-  image_edgeAgent: mcr.microsoft.com/azureiotedge-agent:1.4
+  image_edgeHub: mcr.microsoft.com/azureiotedge-hub:1.6
+  image_edgeAgent: mcr.microsoft.com/azureiotedge-agent:1.6
   image_friendMod: $(IOTHUB-E2E-REPO-ADDRESS)/default-friend-module:$(Architecture)-v2
   image_testMod: ''
   test_image_tag: ''

--- a/vsts/templates/steps-pre-test.yaml
+++ b/vsts/templates/steps-pre-test.yaml
@@ -3,8 +3,8 @@ parameters:
   repo_address: $(IOTHUB-E2E-REPO-ADDRESS)
   repo_user: $(IOTHUB-E2E-REPO-USER)
   repo_password: $(IOTHUB-E2E-REPO-PASSWORD)
-  image_edgeHub: mcr.microsoft.com/azureiotedge-hub:1.6
-  image_edgeAgent: mcr.microsoft.com/azureiotedge-agent:1.6
+  image_edgeHub: mcr.microsoft.com/azureiotedge-hub:1.5
+  image_edgeAgent: mcr.microsoft.com/azureiotedge-agent:1.5
   image_friendMod: $(IOTHUB-E2E-REPO-ADDRESS)/default-friend-module:$(Architecture)-v2
   image_testMod: ''
   test_image_tag: ''


### PR DESCRIPTION
# What

Move the horton IoT Edge runtime images from `:1.4` to `:1.5`, and re-enable the two image override environment variables that are already documented in `test-runner/README.md`.

```diff
-            self.agentImage = "mcr.microsoft.com/azureiotedge-agent:1.4"
+            self.agentImage = "mcr.microsoft.com/azureiotedge-agent:1.5"
-            self.hubImage = "mcr.microsoft.com/azureiotedge-hub:1.4"
+            self.hubImage = "mcr.microsoft.com/azureiotedge-hub:1.5"
```

# Why

**1.4 is out of support.** `:1.4` resolves to **1.4.43**, the *final* 1.4 release, published **2024-10-10**. The supported lines are **1.5.43** (2026-07-21) and **1.6.0** (2026-07-16).

**We are also running a mismatched pair today.** `scripts/new/install-iotedge.sh` installs the daemon unpinned:

```bash
sudo apt-get install -y aziot-edge      # no version pin
```

which currently gives **`aziot-edge 1.6.0-1`**, while the runtime modules were hardcoded to 1.4.43. Confirmed in the gate logs:

```
Unpacking aziot-edge (1.6.0-1) ...
[INF] - Version - 1.4.43.105359236 (9f72e9db5e558be4f68345e757e659bf489ef492)
```

# Why 1.5 and not 1.6

This PR originally targeted 1.6. That does not work, and the reason is worth recording.

On 1.6 ([build 161703](https://dev.azure.com/azure-iot-sdks/azure-iot-sdks/_build/results?buildId=161703&view=results)) **all six** `edgehub_module` jobs failed deterministically, in every language, on the same four tests -- all of which involve `friendMod`:

```
test_method_call_invoked_on_friend               FAILED
test_inputoutput_module_to_friend_routing        FAILED
test_inputoutput_friend_to_module_routing        ERROR
test_inputoutput_module_test_to_friend_and_back  ERROR
```

`friendMod`'s ModuleClient cannot reach edgeHub 1.6 over mqtts:

```
18:28:22.707  MqttBase uri: mqtts://runnervmtroe5
18:29:22.717  UnauthorizedError: mqtt.js returned Failure on first connection
              (Not authorized): Unable to establish a connection
```

A 60 second connect timeout that mqtt.js reports as "Not authorized", with **no corresponding edgeHub log entry at all**.

Ruled out so far:

| Hypothesis | Evidence against |
|---|---|
| MQTT head not started | `Initializing TLS endpoint on port 8883 for MQTT head` / `Started MQTT head` |
| 8883 not published | identical on 1.4/1.5/1.6: `0.0.0.0:8883->8883/tcp` |
| Deployment config rejected | identical: `Set the following 4 route(s) in edge hub` |
| friendMod container / certs / network | the same container connects fine to the same edgeHub over `wss://<host>:443` as a leaf device seconds earlier |
| Other clients can't use 8883 either | the Python module client connects fine over plain MQTT on 1.6 |
| **TLS 1.3** (`SslProtocols` default changed from `tls1.2` in 1.4 to `tls1.2,tls1.3`) | **disproved twice**: 1.5.43 also enables `Tls12, Tls13` and friendMod is fine; and pinning `SslProtocols=tls1.2` on 1.6 ([build 161754](https://dev.azure.com/azure-iot-sdks/azure-iot-sdks/_build/results?buildId=161754&view=results)) did not help and made the run worse |

So the 1.6 blocker is real but **not yet root-caused**. It is tracked in ADO [#39226664](https://dev.azure.com/msazure/One/_workitems/edit/39226664); the next step there is running 1.6 with `RuntimeLogLevel: debug` on the edgeHub module to see what the MQTT head does with that connection. 1.5 gets us onto a supported line in the meantime without waiting for that.

# The override change

`IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE` and `IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE` are documented in `test-runner/README.md`, but the code had them switched off:

```python
if (
    False                                                    # <-- never true
    and len(os.environ.get("IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE", None) or "") > 0
):
```

They now work as documented. Behaviour is unchanged when the variables are unset, and since ADO exports pipeline variables as environment variables to every task, a consuming pipeline can pin or roll back its own edge image without another change here -- useful for testing the 1.6 work, or if one language needs to move at a different pace.

`image_edgeHub` / `image_edgeAgent` in `vsts/templates/steps-pre-test.yaml` moved to 1.5 too. They are dead today (declared, never referenced anywhere in the repo) but leaving them saying 1.4 would be misleading.

# Gate status -- please read before merging

The `edgehub_module` jobs, which are what this change affects, are **green on 1.5**: 6/6 in [161749](https://dev.azure.com/azure-iot-sdks/azure-iot-sdks/_build/results?buildId=161749&view=results) and 6/6 again in [161758](https://dev.azure.com/azure-iot-sdks/azure-iot-sdks/_build/results?buildId=161758&view=results).

The overall gate is nevertheless **red on both runs**, each time on a different `iothub` suite:

| Build | Failing job | Failing test |
|---|---|---|
| 161749 | `py311_mqtt_iothub_module_and_device_async` | `test_twin_desired_props` |
| 161758 | `java_mqtt_iothub_module` | `test_twin_reported_props_5_times` |

Both are `iothub` scenarios, which deploy no edge runtime at all, so they cannot be affected by the image version. Both are the same failure shape: a twin operation against the language wrapper returns HTTP 500 after the wrapper blocks for 60 seconds waiting on the SDK's synchronous twin API.

That is a **pre-existing flake in the wrappers, not something this PR introduces or fixes** -- it is the same problem that led to this investigation in the first place. It does mean this PR cannot go green on its own, and that the gate is unreliable independently of the IoT Edge version. Worth deciding whether to merge on the strength of the `edgehub_module` results, or to fix the twin flake first.

# Blast radius

This changes the edgeHub/edgeAgent version for **every** language gate -- Java, Python, Node, C, C#. That is deliberate: all of them are on the EOL 1.4 line today. If a specific gate needs to stay behind, it can now set `IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE` / `IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE` in its own pipeline rather than blocking this.

# Validation

`python -m py_compile bin/deploy/edge_configuration.py` passes. Gate evidence as above.
