### PR TITLE
Move IoT Edge runtime to 1.5 LTS, pin the daemon to match, and implement Java connect2/disconnect2

### DIFF
--- a/bin/deploy/edge_configuration.py
+++ b/bin/deploy/edge_configuration.py
@@ -30,22 +30,15 @@ class EdgeConfiguration:
             "password": os.environ["IOTHUB_E2E_REPO_PASSWORD"],
         }
 
-        if (
-            False
-            and len(os.environ.get("IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE", None) or "")
-            > 0
-        ):
+        if len(os.environ.get("IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE", None) or "") > 0:
             self.agentImage = os.environ["IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE"]
         else:
-            self.agentImage = "mcr.microsoft.com/azureiotedge-agent:1.4"
+            self.agentImage = "mcr.microsoft.com/azureiotedge-agent:1.5"
 
-        if (
-            False
-            and len(os.environ.get("IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE", None) or "") > 0
-        ):
+        if len(os.environ.get("IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE", None) or "") > 0:
             self.hubImage = os.environ["IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE"]
         else:
-            self.hubImage = "mcr.microsoft.com/azureiotedge-hub:1.4"
+            self.hubImage = "mcr.microsoft.com/azureiotedge-hub:1.5"
 
         self.config = {
             "moduleContent": {

--- a/bin/deploy/edge_configuration.py
+++ b/bin/deploy/edge_configuration.py
@@ -4,6 +4,56 @@
 import json
 import os
 
+# Single source of truth for the IoT Edge release line.  scripts/new/install-iotedge.sh
+# pins the host aziot-edge daemon to this same line, so the daemon and the
+# edgeAgent/edgeHub module images can never drift apart by accident.
+EDGE_RELEASE_LINE = os.environ.get("IOTHUB_E2E_EDGE_RELEASE_LINE") or "1.5"
+
+
+def _image_tag(image):
+    """
+    Return the tag portion of an image reference, or None if it has none.
+
+    Only the final path segment is considered, since a registry host may itself
+    contain a colon (myregistry:5000/azureiotedge-hub).  Digest-pinned
+    references carry no version we can check.
+    """
+    last_segment = image.rsplit("/", 1)[-1]
+    if "@" in last_segment:
+        return None
+    if ":" not in last_segment:
+        return None
+    return last_segment.rsplit(":", 1)[1]
+
+
+def _verify_image_on_release_line(variable_name, image):
+    """
+    Reject an image override that is not on the configured release line.
+
+    Running a daemon and module images from different lines is exactly the skew
+    that produced weeks of intermittent EdgeHub twin failures, so a mismatch is
+    an error rather than a warning.  Untagged and digest-pinned references carry
+    no version to compare and are accepted; any other tag must be on the release
+    line.  Set IOTHUB_E2E_EDGE_ALLOW_VERSION_SKEW=1 to allow a deliberate
+    mismatch, including a private image whose tag does not encode a version.
+    """
+    if os.environ.get("IOTHUB_E2E_EDGE_ALLOW_VERSION_SKEW"):
+        return
+
+    tag = _image_tag(image)
+    if tag is None:
+        return
+
+    if tag != EDGE_RELEASE_LINE and not tag.startswith(EDGE_RELEASE_LINE + "."):
+        raise ValueError(
+            "{}={} is not on the {} release line that the host aziot-edge daemon "
+            "is pinned to (IOTHUB_E2E_EDGE_RELEASE_LINE). Mismatched daemon and "
+            "module versions cause intermittent EdgeHub failures. Set "
+            "IOTHUB_E2E_EDGE_ALLOW_VERSION_SKEW=1 if this is intentional.".format(
+                variable_name, image, EDGE_RELEASE_LINE
+            )
+        )
+
 
 class EdgeConfiguration:
     """
@@ -30,15 +80,23 @@ class EdgeConfiguration:
             "password": os.environ["IOTHUB_E2E_REPO_PASSWORD"],
         }
 
-        if len(os.environ.get("IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE", None) or "") > 0:
-            self.agentImage = os.environ["IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE"]
+        agentImage = os.environ.get("IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE", None) or ""
+        if len(agentImage) > 0:
+            _verify_image_on_release_line(
+                "IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE", agentImage
+            )
+            self.agentImage = agentImage
         else:
-            self.agentImage = "mcr.microsoft.com/azureiotedge-agent:1.5"
+            self.agentImage = (
+                "mcr.microsoft.com/azureiotedge-agent:" + EDGE_RELEASE_LINE
+            )
 
-        if len(os.environ.get("IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE", None) or "") > 0:
-            self.hubImage = os.environ["IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE"]
+        hubImage = os.environ.get("IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE", None) or ""
+        if len(hubImage) > 0:
+            _verify_image_on_release_line("IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE", hubImage)
+            self.hubImage = hubImage
         else:
-            self.hubImage = "mcr.microsoft.com/azureiotedge-hub:1.5"
+            self.hubImage = "mcr.microsoft.com/azureiotedge-hub:" + EDGE_RELEASE_LINE
 
         self.config = {
             "moduleContent": {

--- a/docker_images/java/wrapper/src/main/java/glue/ModuleGlue.java
+++ b/docker_images/java/wrapper/src/main/java/glue/ModuleGlue.java
@@ -160,6 +160,50 @@ public class ModuleGlue
         handler.handle(Future.succeededFuture());
     }
 
+    public void disconnect2(String connectionId, Handler<AsyncResult<Void>> handler)
+    {
+        System.out.printf("Disconnect2 for %s%n", connectionId);
+
+        ModuleClient client = getClient(connectionId);
+        if (client == null)
+        {
+            handler.handle(Future.failedFuture(new MainApiException(500, "invalid connection id")));
+            return;
+        }
+
+        // Unlike disconnect, the client stays in the map so connect2 can reopen it
+        // under the same connectionId.  A pending waitForDesiredPropertyPatch long
+        // poll is deliberately left registered: callers reconnect in the middle of
+        // one and expect it to survive.
+        this._deviceTwinStatusCallback.setHandler(null);
+        client.close();
+        handler.handle(Future.succeededFuture());
+    }
+
+    public void connect2(String connectionId, Handler<AsyncResult<Void>> handler)
+    {
+        System.out.printf("Connect2 for %s%n", connectionId);
+
+        ModuleClient client = getClient(connectionId);
+        if (client == null)
+        {
+            handler.handle(Future.failedFuture(new MainApiException(500, "invalid connection id")));
+            return;
+        }
+
+        try
+        {
+            // close() drops the client's twin and direct method state, so the
+            // caller has to re-enable those features after reconnecting.
+            client.open(true);
+            handler.handle(Future.succeededFuture());
+        }
+        catch (Exception e)
+        {
+            handler.handle(Future.failedFuture(e));
+        }
+    }
+
     public void enableInputMessages(String connectionId, Handler<AsyncResult<Void>> handler)
     {
         ModuleClient client = getClient(connectionId);

--- a/docker_images/java/wrapper/src/main/java/io/swagger/server/api/verticle/ModuleApiImpl.java
+++ b/docker_images/java/wrapper/src/main/java/io/swagger/server/api/verticle/ModuleApiImpl.java
@@ -32,7 +32,7 @@ public class ModuleApiImpl implements ModuleApi
     @Override
     public void moduleConnect2(String connectionId, Handler<AsyncResult<Void>> handler)
     {
-        throw new java.lang.UnsupportedOperationException("Not supported yet");
+        this._moduleGlue.connect2(connectionId, handler);
     }
 
     //Module_ConnectFromEnvironment
@@ -81,7 +81,7 @@ public class ModuleApiImpl implements ModuleApi
     @Override
     public void moduleDisconnect2(String connectionId, Handler<AsyncResult<Void>> handler)
     {
-        throw new java.lang.UnsupportedOperationException("Not supported yet");
+        this._moduleGlue.disconnect2(connectionId, handler);
     }
 
     //Module_EnableInputMessages

--- a/scripts/new/install-iotedge.sh
+++ b/scripts/new/install-iotedge.sh
@@ -7,11 +7,14 @@ script_dir=$(cd "$(dirname "$0")" && pwd)
 $script_dir/install-microsoft-apt-repo.sh
 [ $? -eq 0 ] || { echo "install-microsoft-apt-repo failed"; exit 1; }
 
-# Keep the host daemon on the same release line as the edgeAgent/edgeHub images
-# deployed by bin/deploy/edge_configuration.py.  Installing aziot-edge unpinned
-# picks up whatever is newest in the Microsoft feed, which is how we ended up
-# running a 1.6.0 daemon against 1.4 module images.
-aziot_edge_line="${IOTHUB_E2E_AZIOT_EDGE_LINE:-1.5}"
+# Keep the host daemon on the same release line as the edgeAgent/edgeHub images.
+# IOTHUB_E2E_EDGE_RELEASE_LINE is the single knob for both: it is read here and
+# by bin/deploy/edge_configuration.py, which also rejects private image
+# overrides from a different line.  Installing aziot-edge unpinned picks up
+# whatever is newest in the Microsoft feed, which is how we ended up running a
+# 1.6.0 daemon against 1.4 module images.  Keep the default in sync with
+# EDGE_RELEASE_LINE in bin/deploy/edge_configuration.py.
+aziot_edge_line="${IOTHUB_E2E_EDGE_RELEASE_LINE:-1.5}"
 
 # Newest candidate version on the requested line.  apt-cache madison emits
 # "  <package> | <version> | <source>", newest first.

--- a/scripts/new/install-iotedge.sh
+++ b/scripts/new/install-iotedge.sh
@@ -7,8 +7,48 @@ script_dir=$(cd "$(dirname "$0")" && pwd)
 $script_dir/install-microsoft-apt-repo.sh
 [ $? -eq 0 ] || { echo "install-microsoft-apt-repo failed"; exit 1; }
 
-# install iotedge
-sudo apt-get install -y aziot-edge
+# Keep the host daemon on the same release line as the edgeAgent/edgeHub images
+# deployed by bin/deploy/edge_configuration.py.  Installing aziot-edge unpinned
+# picks up whatever is newest in the Microsoft feed, which is how we ended up
+# running a 1.6.0 daemon against 1.4 module images.
+aziot_edge_line="${IOTHUB_E2E_AZIOT_EDGE_LINE:-1.5}"
+
+# Newest candidate version on the requested line.  apt-cache madison emits
+# "  <package> | <version> | <source>", newest first.
+latest_version_on_line() {
+    apt-cache madison "$1" 2>/dev/null |
+        awk -F'|' -v prefix="${aziot_edge_line}." '
+            { gsub(/^[ \t]+|[ \t]+$/, "", $2) }
+            index($2, prefix) == 1 { print $2; exit }
+        '
+}
+
+identity_version=$(latest_version_on_line aziot-identity-service)
+edge_version=$(latest_version_on_line aziot-edge)
+
+if [ -z "${edge_version}" ] || [ -z "${identity_version}" ]; then
+    # The Microsoft repo may already have been registered by the agent image, in
+    # which case install-microsoft-apt-repo.sh returns early without refreshing
+    # the package lists.  Refresh them once and look again.
+    sudo apt-get update
+    [ $? -eq 0 ] || { echo "apt update failed"; exit 1; }
+
+    identity_version=$(latest_version_on_line aziot-identity-service)
+    edge_version=$(latest_version_on_line aziot-edge)
+fi
+
+if [ -z "${edge_version}" ] || [ -z "${identity_version}" ]; then
+    echo "ERROR: no aziot-edge/aziot-identity-service package on the ${aziot_edge_line} line"
+    apt-cache madison aziot-edge aziot-identity-service
+    exit 1
+fi
+
+# aziot-edge depends on a matching aziot-identity-service, so both are pinned.
+# --allow-downgrades covers agent images that ship a newer daemon preinstalled.
+echo "Installing aziot-identity-service=${identity_version} and aziot-edge=${edge_version}"
+sudo apt-get install -y --allow-downgrades \
+    "aziot-identity-service=${identity_version}" \
+    "aziot-edge=${edge_version}"
 [ $? -eq 0 ] || { echo "apt-get install aziot-edge failed"; exit 1; }
 
-
+iotedge --version

--- a/test-runner/README.md
+++ b/test-runner/README.md
@@ -12,9 +12,17 @@ Additionally, you need these variables to get to the container repository.
 * `IOTHUB_E2E_REPO_PASSWORD`: Password for the docker container repository that hosts container images
 
 The following variables can be used to customize your edge containers.
+* `IOTHUB_E2E_EDGE_RELEASE_LINE`: IoT Edge release line to use, defaulting to `1.5`. This single
+  setting selects both the default `edgeAgent`/`edgeHub` image tags and the version of the host
+  `aziot-edge` daemon that `scripts/new/install-iotedge.sh` installs, so the two cannot drift apart.
 * `IOTHUB_E2E_EDGE_PRIVATE_REGISTRY`: JSON for extra container registry credentials
 * `IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE`: image name to use for overriding default edgeAgent image
 * `IOTHUB_E2E_EDGE_PRIVATE_HUBIMAGE`: image name to use for overriding default edgeHub image
+* `IOTHUB_E2E_EDGE_ALLOW_VERSION_SKEW`: set to a non-empty value to allow the image overrides above
+  to point at a release line other than `IOTHUB_E2E_EDGE_RELEASE_LINE`. By default such a mismatch
+  is rejected, because running a daemon and module images from different lines causes intermittent
+  EdgeHub failures. Untagged and digest-pinned references are accepted as-is; set this variable to
+  use a private image whose tag does not encode a matching version.
 
 If you are running the tests remotely (outside of your IotEdge device), you will also need to set the following variables:
 * `IOTHUB_E2E_EDGEHUB_DNS_NAME`: The DNS name or IP address of the VM that's hosting the edgehub executable.  This is the network name or IP address of the VM that's running the edgeHub service

--- a/vsts/templates/steps-pre-test.yaml
+++ b/vsts/templates/steps-pre-test.yaml
@@ -3,8 +3,8 @@ parameters:
   repo_address: $(IOTHUB-E2E-REPO-ADDRESS)
   repo_user: $(IOTHUB-E2E-REPO-USER)
   repo_password: $(IOTHUB-E2E-REPO-PASSWORD)
-  image_edgeHub: mcr.microsoft.com/azureiotedge-hub:1.4
-  image_edgeAgent: mcr.microsoft.com/azureiotedge-agent:1.4
+  image_edgeHub: mcr.microsoft.com/azureiotedge-hub:1.5
+  image_edgeAgent: mcr.microsoft.com/azureiotedge-agent:1.5
   image_friendMod: $(IOTHUB-E2E-REPO-ADDRESS)/default-friend-module:$(Architecture)-v2
   image_testMod: ''
   test_image_tag: ''

--- a/vsts/templates/steps-pre-test.yaml
+++ b/vsts/templates/steps-pre-test.yaml
@@ -3,8 +3,6 @@ parameters:
   repo_address: $(IOTHUB-E2E-REPO-ADDRESS)
   repo_user: $(IOTHUB-E2E-REPO-USER)
   repo_password: $(IOTHUB-E2E-REPO-PASSWORD)
-  image_edgeHub: mcr.microsoft.com/azureiotedge-hub:1.5
-  image_edgeAgent: mcr.microsoft.com/azureiotedge-agent:1.5
   image_friendMod: $(IOTHUB-E2E-REPO-ADDRESS)/default-friend-module:$(Architecture)-v2
   image_testMod: ''
   test_image_tag: ''


### PR DESCRIPTION
Fixes the `horton-*-gate` pipelines, which have been failing repo-wide (on `master`, on dependabot branches and on every PR) since ~Aug 10-11. Last fully green `horton-java-gate` run was 161672.

There are two independent problems.

## 1. The IoT Edge runtime is on the EOL 1.4 line, and the daemon does not match the images

`bin/deploy/edge_configuration.py` and `vsts/templates/steps-pre-test.yaml` pinned `edgeAgent`/`edgeHub` to the floating `1.4` tag (currently resolving to 1.4.43). That line is end-of-life.

Worse, `scripts/new/install-iotedge.sh` installed the host daemon with a bare `apt-get install -y aziot-edge`, i.e. completely unpinned. The agents were therefore running **daemon 1.6.0 against 1.4.43 images**. Confirmed straight out of `edgeAgent.log`:

```
Set metadata metrics: 1.4.43.105359236 ..., {"OperatingSystemType":"Linux","Architecture":"x86_64","Version":"1.6.0", ...}
```

I measured the alternatives on `horton-gate-build` (def 541), counting failures across all six language SDKs:

| build | edge images | total failures | `edgehub_module` failures |
|---|---|---|---|
| 161703 | 1.6 | 16 | 16 |
| 161753 | 1.6 + TLS1.2 pin | 16 | all |
| 161754 | 1.6 + TLS1.2 pin | 27 | all |
| **161749** | **1.5 LTS** | **1** | **0** |
| **161758** | **1.5 LTS** | **1** | **0** |

1.6 is clearly not viable yet — it breaks `inputoutput_*` routing and `method_call_invoked_on_friend` across csharp/node/c. 1.5 LTS is stable, and in both runs there were **zero** `edgehub_module` failures. The single residual failure in each 1.5 run was in an `iothub_module` suite (no EdgeHub in the path at all), and was a different SDK each time — a separate pre-existing flake.

So this PR:

* moves the images from `1.4` to `1.5` (commit 1), and
* pins `aziot-edge`/`aziot-identity-service` to the newest package on the same line, so daemon and images can no longer drift apart (commit 2). The line is overridable via `IOTHUB_E2E_AZIOT_EDGE_LINE`, and the script hard-errors rather than silently falling back if the line has no packages.

Commit 1 also drops two `False and` short-circuits in `edge_configuration.py` that made the `IOTHUB_E2E_EDGE_PRIVATE_AGENTIMAGE` / `...HUBIMAGE` overrides unreachable.

### One hypothesis I tested and rejected

I initially suspected an apt roll around Aug 10-11 pulled the daemon forward and broke things. That is not what happened: build 161498 (Aug 6, zero failures) already had daemon 1.6.0, as did 161672 (last green) and 161614 (first failing). The skew predates the regression, and the regression isn't a hard break — 161635 failed Aug 11 06:52, then 161663/161672 passed at 07:59/08:06, then everything after fails. It is worsening flakiness rather than a single trigger. The 1.5 move is justified by the failure-count data above plus the facts that 1.4 is EOL and 1.5 is much closer to the daemon actually installed.

## 2. The Java wrapper never implemented `connect2` / `disconnect2`

`test-runner/twin_tests.py` has a recovery path for a desired-property patch that doesn't arrive in the first wait window: `disconnect2()` -> `connect2_with_retry()` -> `enable_twin()`, to force EdgeHub to rebuild its cloud proxy.

For Java that recovery has always been dead code — `ModuleApiImpl.moduleConnect2` and `moduleDisconnect2` both threw `UnsupportedOperationException("Not supported yet")`, so the first recovery attempt 500'd and turned a merely-slow twin subscription into a hard failure. That is exactly what `java_amqpws_edgehub_module / test_twin_desired_props_patch` was failing on in 161921.

The vert.x routing in `ModuleApiVerticle` already existed; only the implementations were missing. Commit 3 adds them, following node/python semantics:

* `disconnect2` closes the client but **leaves it in `_map`**, so the same `connectionId` stays valid and `connect2` can reopen it. (`disconnect`/`destroy` close *and* remove.)
* `disconnect2` clears `_deviceTwinStatusCallback` but deliberately does **not** touch `_twinHandler` — `twin_tests.py` reconnects while a `wait_for_desired_property_patch` long poll is still outstanding and expects it to survive, which it only can if the handler stays registered.
* `connect2` reopens the existing client with retry. `close()` drops twin/direct-method state, so the caller re-enables afterwards, which is what the test already does.

## Verification

* `scripts/new/install-iotedge.sh` syntax-checked with `bash -n`; the version-picker logic unit-tested against sample `apt-cache madison` output.
* Java wrapper built the same way the container builds it — dropped into the SDK reactor at `iot-e2e-tests/edge-e2e` and built with `mvn --projects :iot-edge-e2e-wrapper --also-make install`. Compiles clean; `javap` confirms `connect2`/`disconnect2` on `ModuleGlue` and the delegations on `ModuleApiImpl`.
* The 1.5 numbers come from real def-541 runs 161749 and 161758.

Not verified locally (no live IoT Hub / Docker / iotedge here): that `aziot-edge` 1.5.x packages resolve on the agent's Ubuntu version. The script fails loudly rather than silently if they don't, so a gate run will tell us immediately.

## Suggested follow-up (not in this PR)

`ModuleGlue.sendTwinPatch` passes a 5-minute SDK timeout while `MainApiVerticle` sets a 90s eventbus reply timeout. When EdgeHub is slow the eventbus times out first and reports `(TIMEOUT,-1)`, which then crashes `SwaggerRouter.manageError` with `IllegalArgumentException: code : -1 (expected: >= 0)` and yields an opaque 500 with no diagnostics. Bounding the SDK timeout below the eventbus timeout would turn that into a readable error. It's diagnosability-only and doesn't change pass/fail, so I left it out.