### PR TITLE
Fix timeout inversion that turned slow wrapper operations into opaque 500s

### DIFF
--- a/docker_images/java/wrapper/src/main/java/glue/ModuleGlue.java
+++ b/docker_images/java/wrapper/src/main/java/glue/ModuleGlue.java
@@ -49,6 +49,11 @@ public class ModuleGlue
     HashMap<String, ModuleClient> _map = new HashMap<>();
     int _clientCount = 0;
 
+    // How long an individual SDK operation is allowed to take. This has to stay below both the eventbus send timeout
+    // in MainApiVerticle and the test runner's default_api_timeout (150s), so that a slow operation is reported by the
+    // SDK, which knows what actually went wrong, rather than by one of the layers wrapping it, which do not.
+    private static final int OPERATION_TIMEOUT_MILLIS = 120 * 1000;
+
     public void connectFromEnvironment(String transportType, Handler<AsyncResult<ConnectResponse>> handler)
     {
         System.out.printf("ConnectFromEnvironment called with transport %s%n", transportType);
@@ -662,7 +667,7 @@ public class ModuleGlue
             this._deviceTwinStatusCallback.setHandler(handler);
             try
             {
-                client.updateReportedProperties(reportedProperties, 5 * 60 * 1000);
+                client.updateReportedProperties(reportedProperties, OPERATION_TIMEOUT_MILLIS);
                 handler.handle(Future.succeededFuture());
             }
             catch (Exception e)

--- a/docker_images/java/wrapper/src/main/java/io/swagger/server/api/MainApiVerticle.java
+++ b/docker_images/java/wrapper/src/main/java/io/swagger/server/api/MainApiVerticle.java
@@ -30,6 +30,17 @@ public class MainApiVerticle extends AbstractVerticle {
     private int serverPort = 8080;
     protected Router router;
 
+    // How long the HTTP layer waits for a handler on the eventbus to reply.
+    //
+    // This must be the *outermost* timeout inside the wrapper. When the eventbus gives up first it reports the failure
+    // as (TIMEOUT, -1), and HttpResponseStatus.valueOf(-1) then throws IllegalArgumentException, so the caller sees an
+    // opaque 500 instead of the real error. Previously this was 90s while a twin patch was allowed 5 minutes, so any
+    // operation slower than 90s produced that opaque 500 even though it was still legitimately in progress. The same
+    // applied to the wait_for_desired_property_patch long poll, which the test runner keeps open for up to 150s.
+    //
+    // Ordering, innermost first: SDK operation (120s) < test runner default_api_timeout (150s) < this (300s).
+    private static final long EVENTBUS_SEND_TIMEOUT_MILLIS = 300 * 1000L;
+
     public int getServerPort() {
         return serverPort;
     }
@@ -76,7 +87,7 @@ public class MainApiVerticle extends AbstractVerticle {
         Router swaggerRouter = SwaggerRouter.swaggerRouter(router, swagger, vertx.eventBus(), new OperationIdServiceIdResolver(), new Function<RoutingContext, DeliveryOptions>() {
             @Override
             public DeliveryOptions apply(RoutingContext t) {
-                return new DeliveryOptions().setSendTimeout(90000);
+                return new DeliveryOptions().setSendTimeout(EVENTBUS_SEND_TIMEOUT_MILLIS);
             }
         });
         deployVerticles(startFuture);


### PR DESCRIPTION
## What

Orders the wrapper's timeouts so that a failure is always reported by the layer that knows what actually went wrong.

| layer | before | after |
|---|---|---|
| SDK operation (`ModuleGlue.sendTwinPatch`) | 300s | **120s** |
| test runner `default_api_timeout` | 150s | 150s (unchanged) |
| eventbus `setSendTimeout` (`MainApiVerticle`) | 90s | **300s** |

## Why

The eventbus send timeout was **90s** while a twin patch was allowed **5 minutes**. Any operation slower than 90s was abandoned by the eventbus while it was still legitimately in progress. The eventbus reports that as `(TIMEOUT, -1)`, and `HttpResponseStatus.valueOf(-1)` throws `IllegalArgumentException`, so the test runner just sees:

```
msrest.exceptions.HttpOperationError: Operation returned an invalid status code 'Internal Server Error'
```

with nothing indicating what actually happened.

This is not theoretical. In `horton-java-gate` build 161969, `test_twin_reported_props_5_times` failed on `java_mqttws_edgehub_module` after **107.7s** — past the 90s eventbus timeout but well inside the SDK's own 300s budget. The operation was still running when the layer above it gave up.

The same inversion affected the `wait_for_desired_property_patch` long poll. `twin_tests.py` deliberately keeps that call open for up to 150s (its `wait_schedule = [45, 30, 30]` plus reconnects is documented as needing to stay under `default_api_timeout`), but the eventbus would cut it off at 90s.

## How

Innermost bound first:

```
SDK operation (120s)  <  default_api_timeout (150s)  <  eventbus (300s)
```

- The SDK operation timeout drops from 5 minutes to 120s. 5 minutes was never reachable anyway, since the test runner stops waiting at 150s. At 120s a stuck operation now surfaces a real SDK error inside the runner's window instead of being masked.
- The eventbus becomes the outermost bound, so it can no longer preempt a more meaningful error, and long polls up to 150s are no longer truncated.

Both values are named constants with comments explaining the ordering, so the relationship is not silently broken again.

## Validation

- Compiles on JDK 8 (built through the SDK reactor the way the container build does).
- Note this changes *which* layer reports a failure and removes a premature cutoff; it does not by itself make a genuinely hung operation succeed.

## Related

Follow-up to #436. Separate from #437, which tracks the C wrapper's unimplemented `connect2`/`disconnect2`.