### PR TITLE
Fix node wrapper crashing on unhandled 'error' events

### DIFF
--- a/docker_images/node/wrapper/glue/glueUtils.js
+++ b/docker_images/node/wrapper/glue/glueUtils.js
@@ -161,7 +161,7 @@ var setOptionalCert = function(client, cert, done) {
 var attachErrorHandler = function(emitter, name) {
   if (emitter && typeof emitter.on === 'function' && emitter.listenerCount('error') === 0) {
     emitter.on('error', function(err) {
-      debug(` emitted an error event: ${err ? err.message : 'unspecified error'}`);
+      debug(`${name} emitted an error event: ${err ? err.message : 'unspecified error'}`);
     });
   }
   return emitter;

--- a/docker_images/node/wrapper/glue/glueUtils.js
+++ b/docker_images/node/wrapper/glue/glueUtils.js
@@ -141,6 +141,33 @@ var setOptionalCert = function(client, cert, done) {
 }
 
 /**
+ * Attach a listener for an object's 'error' event.
+ *
+ * The SDK client and twin objects are EventEmitters, and node terminates the process when an
+ * 'error' event is emitted that has no listener registered for it. These objects legitimately emit
+ * 'error' for transient conditions, such as the service rejecting a reconnect attempt or a
+ * subscription failing to be re-established, so without a listener a recoverable blip takes the
+ * whole wrapper process down. That fails the test that is running and every later test that needs
+ * this wrapper, instead of just the operation that was affected.
+ *
+ * This is a no-op if a listener is already attached, so it is safe to call on objects that the SDK
+ * caches and hands back more than once.
+ *
+ * @param {Object} emitter Client or twin object to attach the handler to
+ * @param {string} name    Name of the object, used when logging
+ *
+ * @returns The object that was passed in, so that this can be used inline
+ */
+var attachErrorHandler = function(emitter, name) {
+  if (emitter && typeof emitter.on === 'function' && emitter.listenerCount('error') === 0) {
+    emitter.on('error', function(err) {
+      debug(` emitted an error event: ${err ? err.message : 'unspecified error'}`);
+    });
+  }
+  return emitter;
+}
+
+/**
  * Replace exports from one file with functions exported from another file.  We use this function
  * to make it easier to re-generate the stub code.  With this, we can replace the auto-generated
  * functions in the service directory with their equivalent functions in the glue folder.
@@ -202,5 +229,6 @@ module.exports = {
   makePromise: makePromise,
   transportFromType: transportFromType,
   setOptionalCert: setOptionalCert,
+  attachErrorHandler: attachErrorHandler,
   replaceExports: replaceExports
 }

--- a/docker_images/node/wrapper/glue/internalGlue.js
+++ b/docker_images/node/wrapper/glue/internalGlue.js
@@ -46,9 +46,11 @@ var getModuleOrDeviceTwin = function(objectCache, connectionId, callback) {
   // cheat: use internal member.  We should really call getTwin the first time
   // and cache the value in this code rather than relying on internal implementations.
   if (client._twin) {
-    callback(null, client._twin);
+    callback(null, glueUtils.attachErrorHandler(client._twin, 'twin'));
   } else {
-    client.getTwin(callback);
+    client.getTwin(function(err, twin) {
+      callback(err, glueUtils.attachErrorHandler(twin, 'twin'));
+    });
   }
 }
 
@@ -59,6 +61,7 @@ exports.internal_CreateFromConnectionString = function(objectCache, clientCtor, 
     resolve(clientCtor.fromConnectionString(connectionString, glueUtils.transportFromType(transportType)));
   })
   .then((client) => {
+    glueUtils.attachErrorHandler(client, 'client');
     if (caCertificate && caCertificate.cert) {
       return client.setOptions({
         ca: caCertificate.cert,
@@ -149,8 +152,9 @@ exports.internal_EnableTwin = function(objectCache, connectionId) {
   debug(`internal_EnableTwin called with ${connectionId}`);
   return glueUtils.makePromise('internal_EnableTwin', function(callback) {
     var client = objectCache.getObject(connectionId)
-    client.getTwin(function(err) {
+    client.getTwin(function(err, twin) {
       glueUtils.debugFunctionResult('client.getTwin', err);
+      glueUtils.attachErrorHandler(twin, 'twin');
       callback(err);
     });
   });

--- a/docker_images/node/wrapper/glue/moduleGlue.js
+++ b/docker_images/node/wrapper/glue/moduleGlue.js
@@ -80,6 +80,7 @@ exports.module_CreateFromEnvironment = function(transportType) {
     resolve(ModuleClient.fromEnvironment(glueUtils.transportFromType(transportType)));
   })
   .then((client) => {
+    glueUtils.attachErrorHandler(client, 'client');
     if (client && client._transport && client._transport._mqtt) {
       client._transport._mqtt._options.keepalive = defaultPingInterval;
     }


### PR DESCRIPTION
## Summary

The node wrapper process dies whenever an SDK client or twin emits an `error` event, because it never registers a listener for that event. Node terminates the process when an `EventEmitter` emits `error` with no listener attached, so a single transient service error takes down the whole wrapper.

This is what failed `horton-java-gate` in build **161989**, job `test_linux_amd64_java_mqttws_edgehub_module`.

## What actually happened in build 161989

| Time | Event |
| --- | --- |
| 22:48:39 | edgeHub runs its periodic "refresh of device scope identities cache" |
| 22:48:43.099 | `friendMod` (node, port 8098) gets a clean MQTT close and auto-reconnects. edgeHub rejects it: `UnauthorizedError: mqtt.js returned Failure on first connection (Not authorized)` |
| 22:48:43.103 | `friendMod.log:431` → `throw er; // Unhandled 'error' event` — **the node process dies** |
| 22:48:48.31 | `test_inputoutput_module_to_friend_routing` fails with `ConnectionAborted` / `RemoteDisconnected` (`input_output_tests.py:60`) |
| 22:48:51 / 22:48:54 | the next two tests **ERROR during setup** with `ConnectionRefusedError` on `localhost:8098` |
| 22:48:58.697 | the container restarts by itself (`"Your server is listening on port 8080"`) |

`docker ps -a` in the fetch-logs step confirms the restart: `Created 9 minutes ago … Up 2 minutes`.

**All three test failures were collateral damage from that one process death, not three separate bugs.** The Java `testMod` behaved correctly throughout, other tests in the same job passed before and after, and build 161996 (a re-run of the same PR) succeeded end to end. The client recovers from this kind of rejection on its own — the only reason it was fatal is the missing listener.

## Why the listener belongs on the client

Transport errors alone are harmless: `internal_client.js:39-43` only logs them, with the comment *"errors right now bubble up through the disconnect handler."* The fatal event is emitted on the **client object** by `module_client.js:79`, when the `inputMessage` subscription cannot be re-established — which is exactly what the friend module does for the routing test.

`twin.js:194` does the same thing on the **twin object** when desired property updates cannot be enabled, so twins are covered too.

## Changes

Adds `glueUtils.attachErrorHandler(emitter, name)` and applies it to:

- `internal_CreateFromConnectionString` — immediately after the client is created, **before** `setOptions()` and before caching, so an early reconnect error cannot slip through
- `module_CreateFromEnvironment` — same placement
- `getModuleOrDeviceTwin` and `internal_EnableTwin` — for the `twin.js:194` path

The helper is a no-op when a listener is already present, which keeps the SDK's cached `client._twin` from accumulating a listener on every call.

## Verification

Tested against the **real** `azure-iot-device` SDK and the **real** `glueUtils.js` from this branch.

Subscribing to `inputMessage` on a `ModuleClient` whose connection fails reproduces the production crash exactly:

```
UnauthorizedError: mqtt.js returned Failure on first connection (Not authorized): getaddrinfo ENOTFOUND ...
    at translateError (azure-iot-mqtt-base/dist/mqtt_translate_error.js:71:19)
    at constructor._onEnter (azure-iot-device-mqtt/dist/mqtt.js:85:95)
    ...
node:events:497
      throw er; // Unhandled 'error' event
exit code 1
```

Same error type, same message, and the same `throw er; // Unhandled 'error' event` seen at `friendMod.log:431`.

| Scenario | Result |
| --- | --- |
| Real `inputMessage` connect-failure path, no handler | **crashes**, exit 1 |
| Real `inputMessage` connect-failure path, handler attached | **survives**, exit 0 |
| Synthetic `client.emit('error')`, no handler | **crashes**, exit 1 |
| Synthetic `client.emit('error')`, handler attached | **survives**, exit 0 |
| Helper called 3x on one object | `listenerCount('error') === 1` |
| `jshint` on every changed file | clean |

## Follow-up not included here

`sak_authentication_provider.js:146` emits `error` on the **authentication provider**, and nothing anywhere listens for it. That would crash the wrapper the same way if token renewal ever fails. It is not covered here because the provider is created inside `fromConnectionString` and reaching it means touching a private field. Worth a separate change.

Tracked by ADO work item [39333980](https://dev.azure.com/msazure/One/_workitems/edit/39333980).
