### PR TITLE
Gate reliability: cover the auth provider error path and retry twin operations the service drops

### DIFF
--- a/docker_images/node/wrapper/glue/glueUtils.js
+++ b/docker_images/node/wrapper/glue/glueUtils.js
@@ -168,6 +168,34 @@ var attachErrorHandler = function(emitter, name) {
 }
 
 /**
+ * Attach 'error' listeners to a client and to everything hanging off it that can emit 'error'.
+ *
+ * At the moment that means the client itself and its authentication provider. The authentication
+ * provider is a separate EventEmitter that the SDK never attaches a listener to. It emits 'error'
+ * from its token renewal timer when renewing the SAS token fails, which would take the wrapper
+ * process down in exactly the same way an unhandled client error does. That path matters here
+ * because IotEdgeAuthenticationProvider inherits it from SharedAccessKeyAuthenticationProvider, so
+ * it applies to the edge modules these tests spend most of their time running.
+ *
+ * The provider is only reachable through the transport, which is why this reaches into internals.
+ * X509AuthenticationProvider is not an EventEmitter at all, and attachErrorHandler ignores anything
+ * without an 'on' method, so certificate based clients are unaffected.
+ *
+ * @param {Object} client Client object to attach the handlers to
+ *
+ * @returns The client that was passed in, so that this can be used inline
+ */
+var attachClientErrorHandlers = function(client) {
+  attachErrorHandler(client, 'client');
+
+  if (client && client._transport) {
+    attachErrorHandler(client._transport._authenticationProvider, 'authentication provider');
+  }
+
+  return client;
+}
+
+/**
  * Replace exports from one file with functions exported from another file.  We use this function
  * to make it easier to re-generate the stub code.  With this, we can replace the auto-generated
  * functions in the service directory with their equivalent functions in the glue folder.
@@ -230,5 +258,6 @@ module.exports = {
   transportFromType: transportFromType,
   setOptionalCert: setOptionalCert,
   attachErrorHandler: attachErrorHandler,
+  attachClientErrorHandlers: attachClientErrorHandlers,
   replaceExports: replaceExports
 }

--- a/docker_images/node/wrapper/glue/internalGlue.js
+++ b/docker_images/node/wrapper/glue/internalGlue.js
@@ -61,7 +61,7 @@ exports.internal_CreateFromConnectionString = function(objectCache, clientCtor, 
     resolve(clientCtor.fromConnectionString(connectionString, glueUtils.transportFromType(transportType)));
   })
   .then((client) => {
-    glueUtils.attachErrorHandler(client, 'client');
+    glueUtils.attachClientErrorHandlers(client);
     if (caCertificate && caCertificate.cert) {
       return client.setOptions({
         ca: caCertificate.cert,

--- a/docker_images/node/wrapper/glue/moduleGlue.js
+++ b/docker_images/node/wrapper/glue/moduleGlue.js
@@ -80,7 +80,7 @@ exports.module_CreateFromEnvironment = function(transportType) {
     resolve(ModuleClient.fromEnvironment(glueUtils.transportFromType(transportType)));
   })
   .then((client) => {
-    glueUtils.attachErrorHandler(client, 'client');
+    glueUtils.attachClientErrorHandlers(client);
     if (client && client._transport && client._transport._mqtt) {
       client._transport._mqtt._options.keepalive = defaultPingInterval;
     }

--- a/test-runner/twin_tests.py
+++ b/test-runner/twin_tests.py
@@ -7,7 +7,7 @@ import asyncio
 import sample_content
 import limitations
 from horton_logging import logger
-from utilities import connect2_with_retry
+from utilities import connect2_with_retry, twin_op_with_retry
 
 # Amount of time to wait after updating desired properties.
 wait_time_for_desired_property_updates = 5
@@ -102,7 +102,16 @@ class TwinTests(object):
 
         max_retries = 12
         for retry_count in range(max_retries):
-            twin_received = await client.get_twin()
+            # get_twin can fail outright when edgeHub does not answer it, rather than returning a
+            # twin that has not caught up yet. That is the same intermittent non-response this loop
+            # already tolerates, so it is retried here instead of failing the test on the spot.
+            try:
+                twin_received = await client.get_twin()
+            except Exception as e:
+                logger("get_twin failed ({}). Sleeping for 5 seconds and retrying ({}/{}).".format(
+                    e, retry_count + 1, max_retries))
+                await asyncio.sleep(5)
+                continue
 
             logger("twin sent:    " + str(twin_sent))
             logger("twin received:" + str(twin_received))
@@ -133,7 +142,7 @@ class TwinTests(object):
         # get_twin() round-trip confirms the twin channel is live, so that
         # subsequent desired property patches will be delivered.
         logger("warm-up: verifying twin channel with get_twin")
-        await client.get_twin()
+        await twin_op_with_retry(client.get_twin, "warm-up get_twin")
         logger("warm-up: twin channel is ready")
 
         for i in range(1, 4):
@@ -215,7 +224,9 @@ class TwinTests(object):
         properties_sent = sample_content.make_reported_props()
 
         await client.enable_twin()
-        await client.patch_twin(properties_sent)
+        await twin_op_with_retry(
+            lambda p=properties_sent: client.patch_twin(p), "patch_twin"
+        )
 
         await wait_for_reported_properties_update(
             properties_sent=properties_sent, client=client, registry=registry
@@ -230,10 +241,15 @@ class TwinTests(object):
 
         await client.enable_twin()
 
-        for _ in range(0, 5):
+        for iteration in range(0, 5):
             properties_sent = sample_content.make_reported_props()
 
-            await client.patch_twin(properties_sent)
+            # Sending the same reported properties again is idempotent, so this is safe to retry.
+            # The value is bound as a default argument so the retry cannot pick up a later value.
+            await twin_op_with_retry(
+                lambda p=properties_sent: client.patch_twin(p),
+                "patch_twin {}/5".format(iteration + 1),
+            )
 
             await wait_for_reported_properties_update(
                 properties_sent=properties_sent, client=client, registry=registry

--- a/test-runner/twin_tests.py
+++ b/test-runner/twin_tests.py
@@ -101,15 +101,26 @@ class TwinTests(object):
         await client.enable_twin()
 
         max_retries = 12
+
+        # get_twin can fail outright when edgeHub does not answer it, rather than returning a twin
+        # that has not caught up yet. Those two situations need different budgets. Staleness is
+        # cheap to poll for and gets the full 12 iterations. An outright failure is not cheap,
+        # because each one can occupy the wrapper's REST timeout before it even returns, so letting
+        # all 12 iterations absorb failures would let a sustained edgeHub non-response hold this
+        # test open for far longer than the retry bound used everywhere else. Outright failures get
+        # their own small budget, and the last one is re-raised rather than swallowed.
+        failures_allowed = 3
+
         for retry_count in range(max_retries):
-            # get_twin can fail outright when edgeHub does not answer it, rather than returning a
-            # twin that has not caught up yet. That is the same intermittent non-response this loop
-            # already tolerates, so it is retried here instead of failing the test on the spot.
             try:
                 twin_received = await client.get_twin()
             except Exception as e:
-                logger("get_twin failed ({}). Sleeping for 5 seconds and retrying ({}/{}).".format(
-                    e, retry_count + 1, max_retries))
+                failures_allowed -= 1
+                if not failures_allowed:
+                    logger("get_twin failed ({}). No attempts left, failing the test.".format(e))
+                    raise
+                logger("get_twin failed ({}). Sleeping for 5 seconds and retrying ({} attempts left).".format(
+                    e, failures_allowed))
                 await asyncio.sleep(5)
                 continue
 

--- a/test-runner/utilities.py
+++ b/test-runner/utilities.py
@@ -54,12 +54,20 @@ async def twin_op_with_retry(op, description, retries=3, delay=5):
             return await op()
         except Exception as e:
             last_exc = e
-            logger(
-                "{} attempt {}/{} failed ({}); retrying in {}s".format(
-                    description, attempt + 1, retries, e, delay
+            attempts_left = retries - attempt - 1
+            if attempts_left:
+                logger(
+                    "{} attempt {}/{} failed ({}); retrying in {}s".format(
+                        description, attempt + 1, retries, e, delay
+                    )
                 )
-            )
-            await asyncio.sleep(delay)
+                await asyncio.sleep(delay)
+            else:
+                logger(
+                    "{} attempt {}/{} failed ({}); no attempts left".format(
+                        description, attempt + 1, retries, e
+                    )
+                )
     logger("{} failed after {} attempts".format(description, retries))
     raise last_exc
 

--- a/test-runner/utilities.py
+++ b/test-runner/utilities.py
@@ -29,6 +29,40 @@ async def connect2_with_retry(client, retries=3, delay=5):
             await asyncio.sleep(delay)
     raise last_exc
 
+
+async def twin_op_with_retry(op, description, retries=3, delay=5):
+    """Retry a twin operation that failed because the service never answered it.
+
+    edgeHub intermittently stops responding to a twin operation on a connection that is otherwise
+    healthy.  The client stays connected, no disconnect is reported, and edgeHub simply logs nothing
+    for the operation.  The SDK under test correctly bounds its wait and reports a timeout, which
+    the wrapper turns into a 500, so the operation fails here even though the client did nothing
+    wrong.
+
+    Retrying is deliberately limited to a small number of attempts, and every attempt is logged, so
+    that this hides an intermittent service problem without hiding a real one.  An SDK that is
+    actually broken fails every attempt and still fails the test, and the log still shows that the
+    retries happened.
+
+    Only use this for operations that are safe to repeat: reading a twin, or writing the same
+    reported properties again.  Do not use it in negative or regression tests, which should see the
+    first exception immediately.
+    """
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            return await op()
+        except Exception as e:
+            last_exc = e
+            logger(
+                "{} attempt {}/{} failed ({}); retrying in {}s".format(
+                    description, attempt + 1, retries, e, delay
+                )
+            )
+            await asyncio.sleep(delay)
+    logger("{} failed after {} attempts".format(description, retries))
+    raise last_exc
+
 default_length = 64
 
 


### PR DESCRIPTION
Addresses two items on ADO [39339528](https://dev.azure.com/msazure/One/_workitems/edit/39339528), both aimed at the reliability of the java gate.

## 1. The node wrapper still crashed if the authentication provider emitted an error

#439 attached `error` listeners to the client and twin objects, which stopped one class of unhandled error from killing the wrapper. It left the **authentication provider** uncovered.

The provider is a separate `EventEmitter` and nothing in the SDK or the wrapper listens to it. `sak_authentication_provider.js:146` emits `error` on it from the token renewal timer whenever renewing the SAS token fails, so a renewal failure takes the whole wrapper process down the same way an unhandled client error did — and with it every test that still needed that wrapper.

This is not theoretical for these gates: `IotEdgeAuthenticationProvider extends SharedAccessKeyAuthenticationProvider` and inherits the same emit, so the edge modules these suites spend all their time running are exposed to it.

`glueUtils.attachClientErrorHandlers` now attaches a handler to the client *and* to its authentication provider, and both client creation sites use it. The provider is only reachable through the transport, which is why this reaches into internals — the same way the wrapper already reaches for `client._twin` and the mqtt keepalive. `X509AuthenticationProvider` is not an `EventEmitter`, and `attachErrorHandler` ignores anything without an `on` method, so certificate based clients are unaffected.

**Verified against the real SDK and the real `glueUtils.js`:** the provider is reachable at `client._transport._authenticationProvider` and is a `SharedAccessKeyAuthenticationProvider`. Emitting `error` on it the way the renewal timer does gives `throw er; // Unhandled 'error' event` and exit 1 without the fix, and `SURVIVED` with exit 0 with it, with the listener count going 0 → 1.

## 2. Retrying twin operations the service never answers

This is the single largest source of noise in the java gate. Across the last 40 builds of definition 545, **23 failed**, and every failure was one of the `java_<transport>_edgehub_module` jobs. The transport that fails is effectively random from run to run, and failures land on branches that cannot have caused them, including `main` and dependabot branches that only bump a dependency version.

edgeHub intermittently stops responding to a twin operation on a connection that is otherwise healthy. The client stays connected, no disconnect is reported, and edgeHub logs nothing at all for the operation. The SDK bounds its wait correctly and reports a timeout, the wrapper turns that into a 500, and the test fails even though the client did nothing wrong.

Two examples, both from builds of the same commit:

- **162033**, `test_twin_reported_props_5_times` on mqttws. Patches 1–4 were processed by edgeHub at 19:14:17.842, 19:14:23.249 and 19:14:28.452. The fifth was sent at ~19:14:34 and edgeHub logged nothing for that module until the test gave up. The client stayed CONNECTED from 19:14:21.611 until teardown closed it at 19:16:34.502.
- **162043**, `test_twin_desired_props` on amqp. Same shape, different operation: `Timed out waiting for service to respond to getTwin request`.

`twin_op_with_retry` sits alongside the existing `connect2_with_retry` and is used for the operations seen failing this way: the reported property patches, and the `get_twin` used to warm up the twin channel. The `get_twin` loop in `test_twin_desired_props` already retried a twin that had not caught up yet, but did not survive `get_twin` failing outright, so it now treats that the same way.

### This does not blunt the gate

That was my main concern in writing it, since a retry that swallows everything turns a gate into decoration. Retrying is bounded at three attempts and every attempt is logged. An SDK that is genuinely broken fails all three and still fails the test, **with the original exception**, and the log still shows the retries happened. Only an operation that starts working again on its own is absorbed.

The reported property patches resend the same value, so repeating them is idempotent. The value is bound as a default argument so a retry cannot pick up a later iteration's value.

**Verified with a harness against the real helper:** returns the value and does not retry on success; recovers when an operation fails twice then succeeds; still raises the original exception when every attempt fails; stays bounded at three attempts; binds the correct value per iteration. All 8 checks pass.

## Note on the wider blast radius

`test-runner` is shared by every language, so this changes twin test behaviour for node, c, csharp and python too. I think that is correct — the edgeHub non-response is not language specific, and the failures it causes are not the SDKs' fault — but it is worth a second opinion from someone who owns the other gates.

`jshint` is clean on all changed js files; the python changes compile under 3.11.
